### PR TITLE
Base for CLI tool

### DIFF
--- a/packages/titus-cli/.eslintrc
+++ b/packages/titus-cli/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": ["standard"],
+  "plugins": ["prettier"],
+  "env": {
+    "es6": true,
+    "browser": true,
+    "jest": true
+  }
+}

--- a/packages/titus-cli/.gitignore
+++ b/packages/titus-cli/.gitignore
@@ -1,0 +1,16 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# misc
+.DS_Store
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+package-lock.json
+yarn.lock
+
+lerna-debug.log

--- a/packages/titus-cli/README.md
+++ b/packages/titus-cli/README.md
@@ -1,0 +1,19 @@
+# Titus CLI
+
+## Installation
+
+Install the dependencies using either npm or yarn
+
+```
+npm/yarn install
+```
+
+## Developing
+
+To use the local version of the cli in the command line we need to link it to our global packages and add the bin to our PATH.
+
+```
+npm link
+```
+
+NB. This doesn't work in yarn at the moment. There are several open issues about it, but it is not looking like something that will get resolved.

--- a/packages/titus-cli/package.json
+++ b/packages/titus-cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "titus-cli",
+  "version": "1.0.0",
+  "bin": {
+    "titus": "titus-cli.js"
+  },
+  "dependencies": {
+    "commander": "^2.15.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.19.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0"
+  },
+  "scripts": {
+    "lint": "eslint *.js",
+    "lint:fix": "eslint *.js --fix"
+  }
+}

--- a/packages/titus-cli/titus-cli.js
+++ b/packages/titus-cli/titus-cli.js
@@ -1,0 +1,23 @@
+#! /usr/bin/env node
+'use strict'
+
+const program = require('commander')
+
+const { version } = require('./package.json')
+
+program
+  .version(version, '-v, --version')
+
+program
+  .command('starter')
+  .description('Clone the starter shell')
+  .action(() => {
+    console.log('This is where the magic happens.')
+  })
+
+program.parse(process.argv)
+
+// no arguments passed then show help
+if (!process.argv.slice(2).length) {
+  program.help()
+}

--- a/titus.code-workspace
+++ b/titus.code-workspace
@@ -11,6 +11,9 @@
 		},
 		{
 			"path": "packages/titus-starter"
+		},
+		{
+			"path": "packages/titus-cli"
 		}
 	],
 	"settings": {}


### PR DESCRIPTION
This implementation is very light. To test you need to do the following...

- make sure all dependencies are installed `lerna bootstap`
- cd in to cli package `cd ./packages/titus-cli`
- link to global `npm link`

Now you should be able to run the following

```
# Show usage info
titus
titus -h
titus --help

# Show cli version
titus -v
titus --version

# Empty script for creating new project from starter (shows silly message)
titus starter
```
