### PR TITLE
Add nodemon and watcher task

### DIFF
--- a/packages/titus-components/package.json
+++ b/packages/titus-components/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "nwb build-react-component --no-demo --copy-files",
-    "build:watch": "nodemon -w src -x 'nwb build-react-component --no-demo --copy-files'",
+    "build:watch": "nodemon -w src -x 'npm run build'",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo",
     "test:nwb": "nwb test-react",


### PR DESCRIPTION
Titus Components package uses `nwb` as it was a no config setup. However it sadly doesn't have a watcher task and looking through issues on their GitHub the best solution seemed to be using nodemon.