### PR TITLE
Fixed invalid children in table header

### DIFF
--- a/packages/titus-components/src/table/material/material-ui-table.js
+++ b/packages/titus-components/src/table/material/material-ui-table.js
@@ -73,7 +73,7 @@ class MaterialUiTable extends React.Component {
         />
         <Table>
           <NfTableHeaderRow component={HeaderRow}>
-            <NfTableHeader>
+            {[<NfTableHeader key='select-all'>
               <TableCell padding='checkbox'>
                 <Checkbox
                   color='primary'
@@ -82,21 +82,23 @@ class MaterialUiTable extends React.Component {
                   checked={selecting[0] === 'all'}
                 />
               </TableCell>
-            </NfTableHeader>
+            </NfTableHeader>,
+            ...columns.reduce(
+              (acc, curr, index) => {
+                const { accessor, sortable, label } = curr
+                if (accessor) {
+                  acc.push(
+                    <NfTableHeader
+                      key={index}
+                      sortable={sortable}
+                      accessor={accessor}
+                      component={SortingHeaderCell}>{label}</NfTableHeader>
+                  )
+                }
+                return acc
+              }, [])
+            ]}
 
-            {columns.map(
-              ({ accessor, sortable, label }, index) =>
-                accessor && (
-                  <NfTableHeader
-                    key={index}
-                    sortable={sortable}
-                    accessor={accessor}
-                    component={SortingHeaderCell}
-                  >
-                    {label}
-                  </NfTableHeader>
-                )
-            )}
           </NfTableHeaderRow>
 
           <TableBody>


### PR DESCRIPTION
Problem was two-fold:
1. The `children` prop was composed of a `NfTableHeader` followed by an array of `NfTableHeader`.  They are now merged into a single array.
2. When the `accessor` of a column is falsy, an element is added to the array, which is simply `false`.  Now `Array.map()` is replaced by `Array.reduce()` to exclude these items.
