### PR TITLE
Add back postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint:all": "lerna run lint",
     "test:all": "lerna run test",
     "precommit": "lerna run lint:fix",
-    "prepush": "lerna run test"
+    "prepush": "lerna run test",
+    "postinstall": "lerna bootstrap"
   },
   "devDependencies": {
     "husky": "^0.14.3",


### PR DESCRIPTION
Add back the `postinstall` script so that when first downloaded a `npm install` is enough to have all packages dependencies downloaded.