### PR TITLE
removed router from component dev dependencies

### DIFF
--- a/packages/titus-components/package.json
+++ b/packages/titus-components/package.json
@@ -33,7 +33,6 @@
     "react": "16.x"
   },
   "devDependencies": {
-    "@reach/router": "^1.1.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
This PR fixes the routing in the kitchen-sink app, it was caused by a conflict with the react/router module installed in the devDependencies