### PR TITLE
added JssProvider to avoid conflicts

### DIFF
--- a/packages/titus-kitchen-sink/src/app.js
+++ b/packages/titus-kitchen-sink/src/app.js
@@ -29,7 +29,6 @@ export const apolloClient = new ApolloClient({
 
 const generateClassName = createGenerateClassName()
 
-
 const App = () => (
   <ApolloProvider client={apolloClient}>
     <Provider store={store}>


### PR DESCRIPTION
this PR resolve an issue related to the production bundle.

For some reason the classname are duplicated in the production build and the layout is broken.

This is a know issue https://github.com/mui-org/material-ui/issues/8223

Was salved wrapping the Theme in a custom JssProvider

```
<JssProvider generateClassName={generateClassName}>
  <MuiThemeProvider theme={theme}>
    <Auth loginComponent={<Login authProvider={authProvider} />}>
      <Navigation
        title={meta.appName}
        items={Menu}
        main={Routes}
        headerRight={UserProfile}
      />
    </Auth>
  </MuiThemeProvider>
</JssProvider>
```