### PR TITLE
Add convenience scripts to start and stop the kitchen-sink app

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Some commands have been added to the root package for convenience.
 | postinstall        | runs 'lerna bootstrap' post install |
 | build:component    | build the components project        |
 | start:kitchen-sink | starts the kitchen sink app         |
+| stop:kitchen-sink  | stops the kitchen sink app          |
 
 ### Infrastructure documentation
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test:all": "lerna run test",
     "precommit": "lerna run --parallel format ; lerna run --parallel lint:fix",
     "prepush": "lerna run test",
-    "postinstall": "lerna bootstrap"
+    "postinstall": "lerna bootstrap",
+    "start:kitchen-sink": "lerna run --scope titus-kitchen-sink* --stream start",
+    "stop:kitchen-sink": "lerna run --scope titus-kitchen-sink* --stream stop"
   },
   "devDependencies": {
     "husky": "^0.14.3",

--- a/packages/titus-kitchen-sink-backend/package.json
+++ b/packages/titus-kitchen-sink-backend/package.json
@@ -26,6 +26,7 @@
     "docker:dev:seed:udaru": "docker-compose -f docker/docker-compose-dev.yml exec api npm run dev:seed:udaru",
     "dev:start": "nodemon --ignore pgdata/ -P 5000 -L .",
     "start": "npm run docker:dev:start",
+    "stop": "npm run docker:dev:stop",
     "dev:cleandb": "rm -rf pgdata",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Addresses issue #123 

Note that because the backend kitchen sink app starts a docker compose file, sending a SIGINT to the `lerna run` script which starts frontend and backend doesn't work (IoW, doesn't stop docker). Hence, I added a stop script which calls the `stop` npm scripts, thereby stopping docker as well