### PR TITLE
nginx push state configuration

### DIFF
--- a/packages/titus-kitchen-sink/docker/etc/nginx.conf
+++ b/packages/titus-kitchen-sink/docker/etc/nginx.conf
@@ -65,6 +65,7 @@ http {
             proxy_set_header Host $host;
 
             root    /usr/share/nginx/titus;
+            try_files $uri /index.html;
         }
         location /graphql {
             proxy_pass http://titus-backend;


### PR DESCRIPTION
Addresses issue #103 

Took inspiration from [here](https://medium.com/@johnbrett/create-react-app-push-state-nginx-config-a9f7530621c1).

Note that getting the demo app to work in docker locally requires several changes, meaning that this change is not easy to test, unless you're familiar with the docker setup in the app (which I'm not).

The changes I had to do to make it run locally are:

- move the app's docker file to the app's root (rather than the docker directory)
- change the references to `titus-backend` in the nginx config file to something else (i.e. localhost:12345) so nginx doesn't complain that the host is not resolved
- remove the `proxy_protocol` configuration from the nginx `listen` option (for some reason it does't work)
- use a port other than 80 (probably you need to sudo to listen on that port)

With those changes (plus the change contained in this PR), and obviously after `npm run buid`, I was able to start the app inside a docker container locally and check that hard-refreshing on a non-root path works properly.