### PR TITLE
Fix CLI command name from starter to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The quickest way to get started with Titus is to use the CLI to create a starter
 You can do this by running:
 
 ```
-npx @nearform/titus-cli starter <project-name>
+npx @nearform/titus-cli init <project-name>
 ```
 
 This command will generate frontend and backend starter applications.

--- a/packages/titus-cli/README.md
+++ b/packages/titus-cli/README.md
@@ -4,7 +4,7 @@ A command line application to work with Titus
 
 ## Features
 
-* `starter` command to initialise a new Titus application.
+* `init` command to initialise a new Titus application.
 * The ability to choose between a Titus application for the backend, frontend or both.
 
 ## Installation
@@ -16,19 +16,19 @@ npm install -g @nearform/titus-cli
 If you'd prefer not to install the package globally you can use [`npx`](https://www.npmjs.com/package/npx) which comes bundled with npm 5.2.0 or later. You can use it like so:
 
 ```
-npx @nearform/titus-cli starter <project-name>
+npx @nearform/titus-cli init <project-name>
 ```
 
 ## Usage
 
 ```
-titus starter <project-name>
+titus init <project-name>
 ```
 
 Example
 
 ```
-titus starter my-project
+titus init my-project
 ```
 
 This pulls the latest version of titus starter shell from GitHub and copies it to a new subfolder of the current directory called `my-project/`

--- a/packages/titus-cli/titus-cli.js
+++ b/packages/titus-cli/titus-cli.js
@@ -17,6 +17,9 @@ program
   .arguments('<project>')
   .action(initAction)
 
+// unknown command passed then show help
+program.on('command:*', () => program.help())
+
 program.parse(process.argv)
 
 // no arguments passed then show help


### PR DESCRIPTION
And show help when wrong command name given

Addresses #122 

The problem was with wrong documentation, it mentioned the `starter` command for the CLI, whereas the right command is `init`. It would be one option to keep `starter`, but I think `init` makes more sense and also matches what other such CLIs are doing, with the exception of some, like create-react-app, which doesn't take any commands because the only thing it does is generate the skeleton project. I presume we want commands here because at some point titus will do more than just generating the skeleton.

Also added a fallback to show the help when the command is not recognized, as opposed to showing nothing which is not very helpful. Inspired from [here](https://github.com/tj/commander.js/issues/7#issuecomment-402835339)