### PR TITLE
Fix authorization route path

### DIFF
--- a/packages/titus-kitchen-sink/src/menu.js
+++ b/packages/titus-kitchen-sink/src/menu.js
@@ -83,7 +83,7 @@ const Menu = () => {
         </ListItemIcon>
         <ListItemText primary="Uploader" />
       </ListItemLink>
-      <ListItemLink to={'/authorization'} getProps={isActiveRoute}>
+      <ListItemLink to={'/auth'} getProps={isActiveRoute}>
         <ListItemIcon>
           <AuthIcon />
         </ListItemIcon>

--- a/packages/titus-kitchen-sink/src/routes.js
+++ b/packages/titus-kitchen-sink/src/routes.js
@@ -77,7 +77,7 @@ const Routes = () => (
     <AsyncSearch path="search/*" />
     <AsyncComments path="comments/*" />
     <AsyncUploader path="uploader/*" />
-    <AsyncAuthorization path="authorization/*" />
+    <AsyncAuthorization path="auth/*" />
   </Router>
 )
 


### PR DESCRIPTION
To avoid collisions with the /authorization backend path

The problem is that in the nginx configuration the /authorization path is proxied to the backend. If we use that in one of the routes, hard refreshing on that route errors because it's not going through the "push-state" logic implemented a few days ago.