### PR TITLE
Include lighthouse

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/node:10
+    - image: circleci/node:10-browsers
 
 version: 2
 jobs:
@@ -18,6 +18,22 @@ jobs:
           root: .
           paths:
             - .
+  build:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build the production frontend bundle
+          command: |
+            set -e
+            cd packages/titus-kitchen-sink
+            mv .env.prod .env
+            npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
   lint:
     <<: *defaults
     steps:
@@ -30,7 +46,16 @@ jobs:
       - attach_workspace:
           at: .
       - run: npm run test:all
-  build-push-containers:
+  lighthouse:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run: npm run lighthouse
+      - store_artifacts:
+          path: packages/titus-kitchen-sink/lighthouse-report.html
+          destination: titus-kitchen-sink-lighthouse-report.html
+  push-containers:
     <<: *defaults
     environment:
       DOCKER_REPO: "711655675495.dkr.ecr.us-east-1.amazonaws.com"
@@ -46,13 +71,6 @@ jobs:
             curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
             unzip awscli-bundle.zip
             sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-      - run:
-          name: Build the production frontend bundle
-          command: |
-            set -e
-            cd packages/titus-kitchen-sink
-            mv .env.prod .env
-            npm run build
       - run:
           name: Build the frontend Docker containers
           command: |
@@ -83,16 +101,24 @@ workflows:
   test_and_build:
     jobs:
       - install
+      - build:
+          requires:
+            - install
       - lint:
           requires:
-              - install
+            - install
       #- test:
       #    requires:
       #        - lint
-      - build-push-containers:
+      - lighthouse:
           requires:
-              #- test
-              - lint
+            - build
+      - push-containers:
+          requires:
+            - build
+            #- test
+            - lint
+            - lighthouse
           #filters:
           #  branches:
           #    only: master

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 yarn.lock
 
 lerna-debug.log
+lighthouse-report.html

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prepush": "lerna run test",
     "postinstall": "lerna bootstrap",
     "start:kitchen-sink": "lerna run --scope titus-kitchen-sink* --stream start",
-    "stop:kitchen-sink": "lerna run --scope titus-kitchen-sink* --stream stop"
+    "stop:kitchen-sink": "lerna run --scope titus-kitchen-sink* --stream stop",
+    "lighthouse": "lerna run lighthouse"
   },
   "devDependencies": {
     "husky": "^0.14.3",

--- a/packages/titus-kitchen-sink/lighthouse/index.js
+++ b/packages/titus-kitchen-sink/lighthouse/index.js
@@ -1,0 +1,33 @@
+const lighthouse = require('lighthouse')
+const chromeLauncher = require('chrome-launcher')
+const handler = require('serve-handler')
+const http = require('http')
+const fs = require('fs')
+
+const PORT = 3001
+ 
+const server = http.createServer((request, response) => {
+  return handler(request, response, { public: 'build', renderSingl: true});
+})
+ 
+function launchChromeAndRunLighthouse(url, opts, config = null) {
+  return chromeLauncher.launch({chromeFlags: opts.chromeFlags}).then(chrome => {
+    opts.port = chrome.port;
+    return lighthouse(url, opts, config).then(results => {
+      return chrome.kill().then(() => results)
+    })
+  })
+}
+
+const opts = {
+  chromeFlags: [],
+  output: 'html'
+}
+
+server.listen(PORT, async () => {
+  const results = await launchChromeAndRunLighthouse(`http://localhost:${PORT}`, opts)
+
+  fs.writeFileSync('./lighthouse-report.html', results.report)
+  
+  server.close()
+})

--- a/packages/titus-kitchen-sink/package-lock.json
+++ b/packages/titus-kitchen-sink/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "titus-kitchen-sink",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/helper-module-imports": {
 			"version": "7.0.0",
@@ -13,7 +15,8 @@
 		"@babel/parser": {
 			"version": "7.0.0-beta.53",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-			"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI="
+			"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+			"dev": true
 		},
 		"@babel/runtime": {
 			"version": "7.0.0",
@@ -44,6 +47,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.0.3.tgz",
 			"integrity": "sha512-xWeqqfAg8YAhEZvQhMefPvUSrVhe0RqzbOjFDbp6DELzs+88lrJP2lrsBPTuy/5+O6L+oeNyHy2XwI9C77R2dw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "7.0.0",
 				"@types/jss": "9.5.5",
@@ -78,6 +82,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.1.tgz",
 			"integrity": "sha512-1kNcxYiIT1x8iDPEAlgmKrfRTIV8UyK6fLVcZ9kMHIKGWft9I451V5mvSrbCjbf7MX1TbLWzZjph0aVCRf9MqQ==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "7.0.0",
 				"recompose": "0.29.0"
@@ -87,6 +92,7 @@
 					"version": "0.29.0",
 					"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.29.0.tgz",
 					"integrity": "sha512-J/qLXNU4W+AeHCDR70ajW8eMd1uroqZaECTj6qqDLPMILz3y0EzpYlvrnxKB9DnqcngWrtGwjXY9JeXaW9kS1A==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "7.0.0",
 						"change-emitter": "0.1.6",
@@ -148,6 +154,7 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.10.tgz",
 			"integrity": "sha512-5UptYl8amjWe1hBRqZ8JL/dDxzGGYUF7bYtWVLgI6X4yfkMhG62H4IFARaukYfvUmf86jyPBybPQ6BibQ8eZXg==",
+			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.10",
 				"babel-runtime": "6.26.0",
@@ -165,6 +172,7 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.4.10.tgz",
 			"integrity": "sha512-GIxgSj2/42WgG8iFPOE0nrl7lrSFD/vNC8ipAAHCQYkZR2leFamVmV2M+hntcwxbIeW9RPS3sOoB6+tFEM8dnA==",
+			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.10",
 				"babel-runtime": "6.26.0",
@@ -175,12 +183,14 @@
 		"@storybook/addons": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.10.tgz",
-			"integrity": "sha512-Be/ZxfQ6F434qNQPLK0Q7xNvSMf63LmLZgwoy4mT2fIc2ye2yNXfO7nxh97s5zhMXMGmFispUNiRAMXzbjfpJA=="
+			"integrity": "sha512-Be/ZxfQ6F434qNQPLK0Q7xNvSMf63LmLZgwoy4mT2fIc2ye2yNXfO7nxh97s5zhMXMGmFispUNiRAMXzbjfpJA==",
+			"dev": true
 		},
 		"@storybook/channel-postmessage": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.4.10.tgz",
 			"integrity": "sha512-9gh6CNf55Zq8taBorDO6oZ0oB4FFugtZcjKphtlbZLmuybmhvzgdX5dzdNxc3lIs9F3fF2dWfRdKPJZCeijY9Q==",
+			"dev": true,
 			"requires": {
 				"@storybook/channels": "3.4.10",
 				"global": "4.3.2",
@@ -190,17 +200,20 @@
 		"@storybook/channels": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.4.10.tgz",
-			"integrity": "sha512-ozYnZsPEkSdMmtC+9/CnFXa+ZuQLL/9U1dK9rU2AdrbwkPlHaeGcae1RMlZjgjkHH3PNiuXFLPM8G+R9E7Tx4A=="
+			"integrity": "sha512-ozYnZsPEkSdMmtC+9/CnFXa+ZuQLL/9U1dK9rU2AdrbwkPlHaeGcae1RMlZjgjkHH3PNiuXFLPM8G+R9E7Tx4A==",
+			"dev": true
 		},
 		"@storybook/client-logger": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.10.tgz",
-			"integrity": "sha512-WRINmY3OqVSwBWz62ij9B1MoQsXkI+Slq2qp6RRWSYEh7/7kyNiPbYfX6ODUcPEaUNdXlZgLfDk1alJWGeJrDw=="
+			"integrity": "sha512-WRINmY3OqVSwBWz62ij9B1MoQsXkI+Slq2qp6RRWSYEh7/7kyNiPbYfX6ODUcPEaUNdXlZgLfDk1alJWGeJrDw==",
+			"dev": true
 		},
 		"@storybook/components": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.10.tgz",
 			"integrity": "sha512-0X2H3iCz8JXpSItcAYgxrTQSEnYDaSWiLl3nz303JTkadcmBLJcIMnuQHKGKYLXde6jTkbxbb0AO/wgK7wXCYw==",
+			"dev": true,
 			"requires": {
 				"glamor": "2.20.40",
 				"glamorous": "4.13.1",
@@ -211,6 +224,7 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/core/-/core-3.4.10.tgz",
 			"integrity": "sha512-VByCEHdfJgsETIwC0qvQG9+MY614qCn7cE1t2cGaMG+T+kPWV9YiI7DumWlwFVk+bYgOrLvoXjou38xmKVVF8A==",
+			"dev": true,
 			"requires": {
 				"@storybook/addons": "3.4.10",
 				"@storybook/channel-postmessage": "3.4.10",
@@ -245,6 +259,7 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
 			"integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
+			"dev": true,
 			"requires": {
 				"@storybook/react-komposer": "2.0.4",
 				"@storybook/react-simple-di": "1.3.0",
@@ -255,14 +270,16 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.4.10.tgz",
 			"integrity": "sha512-r6f5UMf7wHFuDYZFQRzBCUoAvQbVh3OprHxupWmbRwZbzPllp+v8klReeeDA9i4HVckrTlNt05rlVe1ToU2lFQ==",
+			"dev": true,
 			"requires": {
 				"npmlog": "4.1.2"
 			}
 		},
 		"@storybook/podda": {
 			"version": "1.2.3",
-			"resolved": "http://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
 			"integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"immutable": "3.8.2"
@@ -272,6 +289,7 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.4.10.tgz",
 			"integrity": "sha512-PwM7znb/JM6zldcPv05sURDRgTANYpxf32ORjatW5wYbJcx77723Inru/1UixFSNEC97kHKA+MjdNSFg+iuGiA==",
+			"dev": true,
 			"requires": {
 				"@storybook/addon-actions": "3.4.10",
 				"@storybook/addon-links": "3.4.10",
@@ -317,14 +335,16 @@
 				"core-js": {
 					"version": "2.5.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+					"dev": true
 				}
 			}
 		},
 		"@storybook/react-komposer": {
 			"version": "2.0.4",
-			"resolved": "http://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.4.tgz",
 			"integrity": "sha1-wsDUp12bSpwMa0bxSrBQ9FitS7A=",
+			"dev": true,
 			"requires": {
 				"@storybook/react-stubber": "1.0.1",
 				"babel-runtime": "6.26.0",
@@ -336,7 +356,8 @@
 				"hoist-non-react-statics": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-					"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+					"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+					"dev": true
 				}
 			}
 		},
@@ -344,6 +365,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
 			"integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"create-react-class": "15.6.3",
@@ -354,7 +376,8 @@
 				"hoist-non-react-statics": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-					"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+					"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+					"dev": true
 				}
 			}
 		},
@@ -362,6 +385,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@storybook/react-stubber/-/react-stubber-1.0.1.tgz",
 			"integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -370,6 +394,7 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.4.10.tgz",
 			"integrity": "sha512-bmSBEiN4tI5WO7inhzM8P74ogftXayhTQnZrPGTxpvTRvWUZU0Ctmcm//GYLCcG5WcBn90SpqpcKXBdkvIaxLw==",
+			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.10",
 				"@storybook/mantra-core": "1.7.2",
@@ -400,24 +425,44 @@
 			"integrity": "sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==",
 			"optional": true
 		},
+		"@types/core-js": {
+			"version": "0.9.46",
+			"resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.46.tgz",
+			"integrity": "sha512-LooLR6XHes9V+kNYRz1Qm8w3atw9QMn7XeZUmIpUelllF9BdryeUKd/u0Wh5ErcjpWfG39NrToU9MF7ngsTFVw==",
+			"dev": true
+		},
 		"@types/graphql": {
 			"version": "0.12.6",
-			"resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+			"resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
 			"integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
 		},
 		"@types/jss": {
 			"version": "9.5.5",
 			"resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.5.tgz",
 			"integrity": "sha512-SvxziE0TAoyYst/bzqdReNLIymrZ4jlgc3ux0qnjeS38jAUXVbD/c8gg58QLVOIb0djRBELIBuywRKtJe+iLtg==",
+			"dev": true,
 			"requires": {
 				"csstype": "2.5.6",
 				"indefinite-observable": "1.0.1"
 			}
 		},
+		"@types/mkdirp": {
+			"version": "0.3.29",
+			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
+			"integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "9.6.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.31.tgz",
+			"integrity": "sha512-kIVlvUBizL51ALNMPbmcZoM7quHyB7J6fLRwQe22JsMp39nrVSHdBeVVS3fnQCK1orxI3O8LScmb8cuiihkAfA==",
+			"dev": true
+		},
 		"@types/prop-types": {
 			"version": "15.5.5",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.5.tgz",
 			"integrity": "sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==",
+			"dev": true,
 			"requires": {
 				"@types/react": "16.4.13"
 			}
@@ -426,6 +471,7 @@
 			"version": "16.4.13",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.13.tgz",
 			"integrity": "sha512-a2Z7UmwnAzZ23bTHV6on141S8vvSC7MEJGG85R5/VG80ybzkt5QJqNzlaJ0Y6OX1dncrXFW8B0vWPIx7QuOUqA==",
+			"dev": true,
 			"requires": {
 				"@types/prop-types": "15.5.5",
 				"csstype": "2.5.6"
@@ -435,9 +481,16 @@
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.14.tgz",
 			"integrity": "sha512-pa7qB0/mkhwWMBFoXhX8BcntK8G4eQl4sIfSrJCxnivTYRQWjOWf2ClR9bWdm0EUFBDHzMbKYS+QYfDtBzkY4w==",
+			"dev": true,
 			"requires": {
 				"@types/react": "16.4.13"
 			}
+		},
+		"@types/rimraf": {
+			"version": "0.0.28",
+			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
+			"integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
+			"dev": true
 		},
 		"@types/zen-observable": {
 			"version": "0.8.0",
@@ -510,6 +563,12 @@
 				"reduce-css-calc": "1.3.0"
 			}
 		},
+		"@zeit/schemas": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.1.1.tgz",
+			"integrity": "sha512-7uBms9Uwzq1GnLK7ar4FvhUONW5PuuASBomeMJ5rREMYxWdm2R0/5iXH2gUm8uqVT1x8U51CGuoaF40Tc0xoJA==",
+			"dev": true
+		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -569,7 +628,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
-					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
 					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
@@ -583,6 +642,7 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.7.1.tgz",
 			"integrity": "sha512-3MwqkQYFEF5tjOgZ9ZSz/FYiOas8U/SypK//8jmux3O8D1FkGDXE70p2/7Kl03idT0CbVKPx0w3MPpjFklHJ4Q==",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3",
 				"array.prototype.flat": "1.2.1",
@@ -606,6 +666,7 @@
 			"version": "6.5.3",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
 			"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "2.0.1",
 				"fast-json-stable-stringify": "2.0.0",
@@ -616,7 +677,8 @@
 		"ajv-keywords": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -821,16 +883,30 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"arch": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+			"integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.6"
 			}
+		},
+		"arg": {
+			"version": "2.0.0",
+			"resolved": "http://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
+			"integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -877,7 +953,8 @@
 		"array-find": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg="
+			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+			"dev": true
 		},
 		"array-find-index": {
 			"version": "1.0.2",
@@ -930,6 +1007,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
 			"integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -940,6 +1018,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
 			"integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -950,6 +1029,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.2.1.tgz",
 			"integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -1020,7 +1100,8 @@
 		"ast-types": {
 			"version": "0.11.5",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
+			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
+			"dev": true
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
@@ -1057,8 +1138,9 @@
 		},
 		"autoprefixer": {
 			"version": "7.2.6",
-			"resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
 			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+			"dev": true,
 			"requires": {
 				"browserslist": "2.11.3",
 				"caniuse-lite": "1.0.30000885",
@@ -1077,6 +1159,12 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+		},
+		"axe-core": {
+			"version": "3.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
+			"integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg==",
+			"dev": true
 		},
 		"axobject-query": {
 			"version": "0.1.0",
@@ -1103,7 +1191,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -1200,6 +1288,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1251,7 +1340,8 @@
 		"babel-helper-evaluate-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-			"integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw=="
+			"integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
+			"dev": true
 		},
 		"babel-helper-explode-assignable-expression": {
 			"version": "6.24.1",
@@ -1267,6 +1357,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -1277,7 +1368,8 @@
 		"babel-helper-flip-expressions": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-			"integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw=="
+			"integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
+			"dev": true
 		},
 		"babel-helper-function-name": {
 			"version": "6.24.1",
@@ -1311,18 +1403,21 @@
 		},
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
-			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
+			"resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
+			"dev": true
 		},
 		"babel-helper-is-void-0": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-			"integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ=="
+			"integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
+			"dev": true
 		},
 		"babel-helper-mark-eval-scopes": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-			"integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ=="
+			"integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
+			"dev": true
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
@@ -1358,7 +1453,8 @@
 		"babel-helper-remove-or-void": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-			"integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ=="
+			"integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
+			"dev": true
 		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
@@ -1376,7 +1472,8 @@
 		"babel-helper-to-multiple-sequence-expressions": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-			"integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw=="
+			"integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
+			"dev": true
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
@@ -1401,6 +1498,7 @@
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
 			"integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+			"dev": true,
 			"requires": {
 				"find-cache-dir": "1.0.0",
 				"loader-utils": "1.1.0",
@@ -1435,7 +1533,7 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
@@ -1465,6 +1563,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz",
 			"integrity": "sha512-flIBfrqAdHWn+4l2cS/4jZEyl+m5EaBHVzTb0aOF+eu/zR7E41/MoCFHPhDNL8Wzq1nyelnXeT+vcL2byFLSZw==",
+			"dev": true,
 			"requires": {
 				"cosmiconfig": "5.0.6"
 			},
@@ -1473,6 +1572,7 @@
 					"version": "5.0.6",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
 					"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+					"dev": true,
 					"requires": {
 						"is-directory": "0.3.1",
 						"js-yaml": "3.12.0",
@@ -1482,12 +1582,14 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"dev": true,
 					"requires": {
 						"argparse": "1.0.10",
 						"esprima": "4.0.1"
@@ -1499,6 +1601,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
 			"integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
+			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "0.3.0"
 			}
@@ -1507,6 +1610,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
 			"integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
+			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "0.3.0"
 			}
@@ -1515,6 +1619,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
 			"integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
+			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "0.3.0",
 				"babel-helper-mark-eval-scopes": "0.3.0",
@@ -1526,6 +1631,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
 			"integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
+			"dev": true,
 			"requires": {
 				"babel-helper-is-void-0": "0.3.0"
 			}
@@ -1534,6 +1640,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
 			"integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
+			"dev": true,
 			"requires": {
 				"babel-helper-flip-expressions": "0.3.0"
 			}
@@ -1541,12 +1648,14 @@
 		"babel-plugin-minify-infinity": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-			"integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ=="
+			"integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
+			"dev": true
 		},
 		"babel-plugin-minify-mangle-names": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
 			"integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
+			"dev": true,
 			"requires": {
 				"babel-helper-mark-eval-scopes": "0.3.0"
 			}
@@ -1554,17 +1663,20 @@
 		"babel-plugin-minify-numeric-literals": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-			"integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg=="
+			"integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
+			"dev": true
 		},
 		"babel-plugin-minify-replace": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-			"integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg=="
+			"integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
+			"dev": true
 		},
 		"babel-plugin-minify-simplify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
 			"integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
+			"dev": true,
 			"requires": {
 				"babel-helper-flip-expressions": "0.3.0",
 				"babel-helper-is-nodes-equiv": "0.0.1",
@@ -1575,14 +1687,16 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
 			"integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
+			"dev": true,
 			"requires": {
 				"babel-helper-is-void-0": "0.3.0"
 			}
 		},
 		"babel-plugin-react-docgen": {
 			"version": "1.9.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
 			"integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
+			"dev": true,
 			"requires": {
 				"babel-types": "6.26.0",
 				"lodash": "4.17.10",
@@ -1591,67 +1705,73 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
 			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-do-expressions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
 			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-function-bind": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
@@ -1663,6 +1783,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -1683,6 +1804,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "6.18.0",
 				"babel-runtime": "6.26.0",
@@ -1704,6 +1826,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "6.24.1",
 				"babel-plugin-syntax-decorators": "6.13.0",
@@ -1716,6 +1839,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
 			"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-do-expressions": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -1959,6 +2083,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -1977,6 +2102,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
 			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-function-bind": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -1985,22 +2111,26 @@
 		"babel-plugin-transform-inline-consecutive-adds": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-			"integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA=="
+			"integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
+			"dev": true
 		},
 		"babel-plugin-transform-member-expression-literals": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
-			"integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
+			"integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
+			"dev": true
 		},
 		"babel-plugin-transform-merge-sibling-variables": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
-			"integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
+			"integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
+			"dev": true
 		},
 		"babel-plugin-transform-minify-booleans": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
-			"integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
+			"integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
+			"dev": true
 		},
 		"babel-plugin-transform-object-rest-spread": {
 			"version": "6.26.0",
@@ -2015,6 +2145,7 @@
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
 			"integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -2074,22 +2205,26 @@
 		"babel-plugin-transform-regexp-constructors": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-			"integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw=="
+			"integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
+			"dev": true
 		},
 		"babel-plugin-transform-remove-console": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-			"integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
+			"integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+			"dev": true
 		},
 		"babel-plugin-transform-remove-debugger": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
-			"integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI="
+			"integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
+			"dev": true
 		},
 		"babel-plugin-transform-remove-undefined": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
 			"integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
+			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "0.3.0"
 			}
@@ -2105,7 +2240,8 @@
 		"babel-plugin-transform-simplify-comparison-operators": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
-			"integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
+			"integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
+			"dev": true
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
@@ -2119,12 +2255,14 @@
 		"babel-plugin-transform-undefined-to-void": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
-			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
+			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
+			"dev": true
 		},
 		"babel-preset-env": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -2162,6 +2300,7 @@
 					"version": "3.2.8",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
 					"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+					"dev": true,
 					"requires": {
 						"caniuse-lite": "1.0.30000885",
 						"electron-to-chromium": "1.3.64"
@@ -2189,6 +2328,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
 			"integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-minify-builtins": "0.3.0",
 				"babel-plugin-minify-constant-folding": "0.3.0",
@@ -2291,6 +2431,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
 			"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-do-expressions": "6.22.0",
 				"babel-plugin-transform-function-bind": "6.22.0",
@@ -2301,6 +2442,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "6.24.1",
 				"babel-plugin-transform-export-extensions": "6.22.0",
@@ -2311,6 +2453,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "6.18.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
@@ -2322,6 +2465,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -2589,7 +2733,8 @@
 		"bowser": {
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-			"integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+			"integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==",
+			"dev": true
 		},
 		"boxen": {
 			"version": "1.3.0",
@@ -2685,7 +2830,8 @@
 		"brcast": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+			"dev": true
 		},
 		"brorand": {
 			"version": "1.1.0",
@@ -2791,7 +2937,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
 				"base64-js": "1.3.0",
@@ -2833,6 +2979,7 @@
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"dev": true,
 			"requires": {
 				"bluebird": "3.5.2",
 				"chownr": "1.0.1",
@@ -2852,7 +2999,8 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
 				}
 			}
 		},
@@ -2964,7 +3112,8 @@
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
-			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg=="
+			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg==",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -2993,12 +3142,19 @@
 		"change-emitter": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+			"dev": true
 		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "2.0.4",
@@ -3023,7 +3179,30 @@
 		"chownr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+			"dev": true
+		},
+		"chrome-devtools-frontend": {
+			"version": "1.0.422034",
+			"resolved": "http://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz",
+			"integrity": "sha1-BxyM4URmt2UwMvzRrRpKaNXjy9k=",
+			"dev": true
+		},
+		"chrome-launcher": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.2.tgz",
+			"integrity": "sha512-E+kTHlGgtitPPu8Rci0E4XBasirKtTn6DjqFn8tTLp/7xCUzqb6lig9Il+HLkcudzKvT/aLxJbzbyNCe03w1AA==",
+			"dev": true,
+			"requires": {
+				"@types/core-js": "0.9.46",
+				"@types/mkdirp": "0.3.29",
+				"@types/node": "9.6.31",
+				"@types/rimraf": "0.0.28",
+				"is-wsl": "1.1.0",
+				"lighthouse-logger": "1.1.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2"
+			}
 		},
 		"ci-info": {
 			"version": "1.5.1",
@@ -3059,7 +3238,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -3127,6 +3306,33 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+		},
+		"clipboardy": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+			"integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+			"dev": true,
+			"requires": {
+				"arch": "2.1.1",
+				"execa": "0.8.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				}
+			}
 		},
 		"cliui": {
 			"version": "2.1.0",
@@ -3232,7 +3438,8 @@
 		"common-tags": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3311,7 +3518,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3360,6 +3568,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
 				"fs-write-stream-atomic": "1.0.10",
@@ -3388,6 +3597,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
 			"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+			"dev": true,
 			"requires": {
 				"is-directory": "0.3.1",
 				"js-yaml": "3.12.0",
@@ -3398,12 +3608,14 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"dev": true,
 					"requires": {
 						"argparse": "1.0.10",
 						"esprima": "4.0.1"
@@ -3457,6 +3669,7 @@
 			"version": "15.6.3",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
 			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.17",
 				"loose-envify": "1.4.0",
@@ -3505,6 +3718,12 @@
 				"which": "1.3.1"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+			"dev": true
+		},
 		"cryptiles": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.2.tgz",
@@ -3540,6 +3759,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"source-map": "0.6.1",
@@ -3556,6 +3776,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
 			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+			"dev": true,
 			"requires": {
 				"hyphenate-style-name": "1.0.2",
 				"isobject": "3.0.1"
@@ -3565,6 +3786,7 @@
 			"version": "0.28.11",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
 			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"css-selector-tokenizer": "0.7.0",
@@ -3585,12 +3807,14 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3602,19 +3826,22 @@
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"js-base64": "2.4.9",
@@ -3625,12 +3852,14 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -3662,6 +3891,7 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
 			"integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+			"dev": true,
 			"requires": {
 				"is-in-browser": "1.1.3"
 			}
@@ -3744,7 +3974,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -3824,7 +4054,8 @@
 		"csstype": {
 			"version": "2.5.6",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.6.tgz",
-			"integrity": "sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ=="
+			"integrity": "sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ==",
+			"dev": true
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -3837,7 +4068,8 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
 		},
 		"d": {
 			"version": "1.0.0",
@@ -3956,7 +4188,8 @@
 		"debounce": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-			"integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+			"integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -3994,7 +4227,8 @@
 		"deepmerge": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
-			"integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
+			"integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
@@ -4091,7 +4325,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -4132,6 +4367,30 @@
 			"requires": {
 				"address": "1.0.3",
 				"debug": "2.6.9"
+			}
+		},
+		"devtools-timeline-model": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/devtools-timeline-model/-/devtools-timeline-model-1.1.6.tgz",
+			"integrity": "sha1-e+Uac7VdcntZe7MN0e0ujiEGOaU=",
+			"dev": true,
+			"requires": {
+				"chrome-devtools-frontend": "1.0.401423",
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"chrome-devtools-frontend": {
+					"version": "1.0.401423",
+					"resolved": "http://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.401423.tgz",
+					"integrity": "sha1-MqibjQTjeKSUvjyNYycXA74cBOo=",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
 			}
 		},
 		"diff": {
@@ -4197,7 +4456,8 @@
 		"dom-helpers": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
+			"dev": true
 		},
 		"dom-serializer": {
 			"version": "0.1.0",
@@ -4219,6 +4479,7 @@
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.5.1.tgz",
 			"integrity": "sha512-+oJbP7WWtNnlImFHwY4BiRwh+geHhi7ZATrGqCSpb5Qlur1FankoBj5IRHvfeMpSs17ZangIhJHMFnLGPg4YOQ==",
+			"dev": true,
 			"requires": {
 				"mutationobserver-shim": "0.3.2",
 				"pretty-format": "22.4.3",
@@ -4228,12 +4489,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"pretty-format": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0",
 						"ansi-styles": "3.2.1"
@@ -4252,7 +4515,8 @@
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+			"dev": true
 		},
 		"domain-browser": {
 			"version": "1.2.0",
@@ -4292,7 +4556,8 @@
 		"dotenv": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+			"dev": true
 		},
 		"dotenv-expand": {
 			"version": "4.2.0",
@@ -4303,6 +4568,7 @@
 			"version": "1.5.7",
 			"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.7.tgz",
 			"integrity": "sha1-xEOVqyHR/SjXmpCUKnsUsd69FF8=",
+			"dev": true,
 			"requires": {
 				"dotenv": "5.0.1"
 			}
@@ -4321,6 +4587,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"inherits": "2.0.3",
@@ -4389,6 +4656,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -4460,7 +4728,8 @@
 		"es5-shim": {
 			"version": "4.5.11",
 			"resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.11.tgz",
-			"integrity": "sha512-7NY8JWNUZGpg+Ade2/ufJ9N6uMCiII5Oyf1H89/AuJKjYqUBU7i5bSnz0rOcIjNzQkvPJ+TfP19BTDP2FJg9pg=="
+			"integrity": "sha512-7NY8JWNUZGpg+Ade2/ufJ9N6uMCiII5Oyf1H89/AuJKjYqUBU7i5bSnz0rOcIjNzQkvPJ+TfP19BTDP2FJg9pg==",
+			"dev": true
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
@@ -4505,7 +4774,8 @@
 		"es6-shim": {
 			"version": "0.35.3",
 			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
-			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
+			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
+			"dev": true
 		},
 		"es6-symbol": {
 			"version": "3.1.1",
@@ -4520,6 +4790,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
 			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+			"dev": true,
 			"requires": {
 				"recast": "0.11.23",
 				"through": "2.3.8"
@@ -4528,17 +4799,20 @@
 				"ast-types": {
 					"version": "0.9.6",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+					"dev": true
 				},
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				},
 				"recast": {
 					"version": "0.11.23",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
 					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+					"dev": true,
 					"requires": {
 						"ast-types": "0.9.6",
 						"esprima": "3.1.3",
@@ -4549,7 +4823,8 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -4608,6 +4883,7 @@
 			"version": "4.19.1",
 			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -4653,6 +4929,7 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"dev": true,
 					"requires": {
 						"co": "4.6.0",
 						"fast-deep-equal": "1.1.0",
@@ -4663,12 +4940,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4676,22 +4955,26 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+					"dev": true
 				},
 				"globals": {
 					"version": "11.7.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+					"dev": true
 				},
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"dev": true,
 					"requires": {
 						"argparse": "1.0.10",
 						"esprima": "4.0.1"
@@ -4700,12 +4983,14 @@
 				"json-schema-traverse": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -4778,6 +5063,7 @@
 			"version": "2.50.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.0.tgz",
 			"integrity": "sha512-10FnBXCp8odYcpUFXGAh+Zko7py0hUWutTd3BN/R9riukH360qNPLYPR3/xV9eu9K7OJDjJrsflBnL6RwxFnlw==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.10"
 			}
@@ -4786,6 +5072,7 @@
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
 			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"dev": true,
 			"requires": {
 				"contains-path": "0.1.0",
 				"debug": "2.6.9",
@@ -4803,6 +5090,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -4828,6 +5116,7 @@
 			"version": "7.11.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
 			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3",
 				"doctrine": "2.1.0",
@@ -4840,6 +5129,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 					"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+					"dev": true,
 					"requires": {
 						"array-includes": "3.0.3"
 					}
@@ -4858,7 +5148,8 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
@@ -4914,6 +5205,21 @@
 				"es5-ext": "0.10.46"
 			}
 		},
+		"event-stream": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+			"integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+			"requires": {
+				"duplexer": "0.1.1",
+				"flatmap-stream": "0.1.0",
+				"from": "0.1.7",
+				"map-stream": "0.0.7",
+				"pause-stream": "0.0.11",
+				"split": "1.0.1",
+				"stream-combiner": "0.2.2",
+				"through": "2.3.8"
+			}
+		},
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -4922,7 +5228,8 @@
 		"events": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-			"integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
+			"integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+			"dev": true
 		},
 		"eventsource": {
 			"version": "0.1.6",
@@ -4966,7 +5273,8 @@
 		"exenv": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-			"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+			"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -5048,7 +5356,7 @@
 		},
 		"express": {
 			"version": "4.16.3",
-			"resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 			"requires": {
 				"accepts": "1.3.5",
@@ -5121,7 +5429,7 @@
 		},
 		"external-editor": {
 			"version": "2.2.0",
-			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
 				"chardet": "0.4.2",
@@ -5243,7 +5551,8 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -5258,7 +5567,25 @@
 		"fast-memoize": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
-			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==",
+			"dev": true
+		},
+		"fast-url-parser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+			"integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				}
+			}
 		},
 		"fastparse": {
 			"version": "1.1.1",
@@ -5316,6 +5643,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
 			"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
 				"schema-utils": "0.4.7"
@@ -5404,6 +5732,11 @@
 				"write": "0.2.1"
 			}
 		},
+		"flatmap-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.0.tgz",
+			"integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA=="
+		},
 		"flatten": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -5413,6 +5746,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.6"
@@ -5470,9 +5804,10 @@
 			}
 		},
 		"formik": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/formik/-/formik-1.2.0.tgz",
-			"integrity": "sha512-WtVCIf5LrFdv2lhhReWPVbKkUai4BEoHCKTjdIklKAk/MjhrnAXJkOJMFq0aA8g8B2KWNs/oXBTkIeEWCIlVuA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/formik/-/formik-1.3.0.tgz",
+			"integrity": "sha512-vW72DluHwQPmCkkSQGlFRAsuVaNElO/zT71FApr7yFHSEA6qBf1socKWcw0muQDp6fvD/Z6wo2itlQLnggP4UA==",
+			"dev": true,
 			"requires": {
 				"create-react-context": "0.2.3",
 				"deepmerge": "2.1.1",
@@ -5489,6 +5824,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -5513,10 +5849,16 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.6"
@@ -5536,6 +5878,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"iferr": "0.1.5",
@@ -6019,6 +6362,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"function-bind": "1.1.1",
@@ -6033,12 +6377,14 @@
 		"fuse.js": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.1.tgz",
-			"integrity": "sha1-YyDLlM5W7JdVyJred1vNuwNY1CU="
+			"integrity": "sha1-YyDLlM5W7JdVyJred1vNuwNY1CU=",
+			"dev": true
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
 				"console-control-strings": "1.1.0",
@@ -6082,6 +6428,7 @@
 			"version": "2.20.40",
 			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
 			"integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.17",
 				"inline-style-prefixer": "3.0.8",
@@ -6094,6 +6441,7 @@
 			"version": "4.13.1",
 			"resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.13.1.tgz",
 			"integrity": "sha512-x9yCGlRrPEkHF63m+WoZXHnpSet5ipS/fxczx5ic0ZKPPd2mMDyCZ0iEhse49OFlag0yxbJTc7k/L0g1GCmCYQ==",
+			"dev": true,
 			"requires": {
 				"brcast": "3.0.1",
 				"csstype": "2.5.6",
@@ -6169,10 +6517,17 @@
 				}
 			}
 		},
+		"glob-slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
+			"integrity": "sha1-/lLvpDMjP3Si/mTHq7m8hIICq5U=",
+			"dev": true
+		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"dev": true,
 			"requires": {
 				"min-document": "2.19.0",
 				"process": "0.5.2"
@@ -6228,7 +6583,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"requires": {
 				"create-error-class": "3.0.2",
@@ -6251,7 +6606,7 @@
 		},
 		"graphql": {
 			"version": "0.13.2",
-			"resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
 			"integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
 			"requires": {
 				"iterall": "1.2.2"
@@ -6383,12 +6738,14 @@
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -6503,7 +6860,8 @@
 		"html-element-attributes": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-1.3.1.tgz",
-			"integrity": "sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA=="
+			"integrity": "sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -6522,6 +6880,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
 			"integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
+			"dev": true,
 			"requires": {
 				"es6-templates": "0.2.3",
 				"fastparse": "1.1.1",
@@ -6563,12 +6922,14 @@
 		"html-tag-names": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.3.tgz",
-			"integrity": "sha512-kY/ck6Q0lGLxGocn86BM8Q4vCTUCY78VN43h0uMGeZ8p9LU3XdSNQR4Rs3JEjrKZSS5iXI1YgzY0g8U1AFDQzA=="
+			"integrity": "sha512-kY/ck6Q0lGLxGocn86BM8Q4vCTUCY78VN43h0uMGeZ8p9LU3XdSNQR4Rs3JEjrKZSS5iXI1YgzY0g8U1AFDQzA==",
+			"dev": true
 		},
 		"html-webpack-plugin": {
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
 			"integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+			"dev": true,
 			"requires": {
 				"bluebird": "3.5.2",
 				"html-minifier": "3.5.20",
@@ -6582,6 +6943,7 @@
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
 					"requires": {
 						"big.js": "3.2.0",
 						"emojis-list": "2.1.0",
@@ -6640,7 +7002,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "1.1.2",
@@ -6648,6 +7010,12 @@
 				"setprototypeof": "1.1.0",
 				"statuses": "1.4.0"
 			}
+		},
+		"http-link-header": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
+			"integrity": "sha1-oitBoMmx4tj6wb8baXxr1TLV9eQ=",
+			"dev": true
 		},
 		"http-parser-js": {
 			"version": "0.4.13",
@@ -6785,6 +7153,7 @@
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+			"dev": true,
 			"requires": {
 				"is-ci": "1.2.1",
 				"normalize-path": "1.0.0",
@@ -6794,14 +7163,16 @@
 				"normalize-path": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-					"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k="
+					"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+					"dev": true
 				}
 			}
 		},
 		"hyphenate-style-name": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -6832,22 +7203,31 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
 		},
+		"image-ssim": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+			"integrity": "sha1-g7Qsei5uS4VQVHf+aRf128VkIOU=",
+			"dev": true
+		},
 		"immutable": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+			"dev": true
 		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
 			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+			"dev": true,
 			"requires": {
 				"import-from": "2.1.0"
 			}
@@ -6856,6 +7236,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+			"dev": true,
 			"requires": {
 				"resolve-from": "3.0.0"
 			}
@@ -6883,6 +7264,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.1.tgz",
 			"integrity": "sha1-CZFUI8yNb36xy3iCrRNGM8mm7cM=",
+			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.4"
 			}
@@ -6890,7 +7272,8 @@
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+			"dev": true
 		},
 		"indexes-of": {
 			"version": "1.0.1",
@@ -6925,6 +7308,7 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
 			"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+			"dev": true,
 			"requires": {
 				"bowser": "1.9.4",
 				"css-in-js-utils": "2.0.1"
@@ -6992,6 +7376,21 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
 			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+		},
+		"intl-messageformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+			"integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+			"dev": true,
+			"requires": {
+				"intl-messageformat-parser": "1.4.0"
+			}
+		},
+		"intl-messageformat-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+			"integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -7116,7 +7515,8 @@
 		"is-dom": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
-			"integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0="
+			"integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -7160,7 +7560,8 @@
 		"is-function": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "4.0.0",
@@ -7173,7 +7574,8 @@
 		"is-in-browser": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
+			"dev": true
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -7518,7 +7920,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -7647,7 +8049,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "1.0.0"
@@ -7775,7 +8177,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -7822,8 +8224,9 @@
 		},
 		"jest-diff": {
 			"version": "22.4.3",
-			"resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"diff": "3.5.0",
@@ -7834,12 +8237,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"pretty-format": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0",
 						"ansi-styles": "3.2.1"
@@ -7856,6 +8261,7 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/jest-dom/-/jest-dom-1.12.0.tgz",
 			"integrity": "sha512-G8LplxieRJDOmTNJN2SzctewT9HoslclwzEW8znch98gSw5KeajIbporSqUuWHPRB8q8UQl0OI6AtUjGrNcniQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"css": "2.2.4",
@@ -7887,7 +8293,8 @@
 		"jest-get-type": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+			"dev": true
 		},
 		"jest-haste-map": {
 			"version": "20.0.5",
@@ -7999,7 +8406,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8057,8 +8464,9 @@
 		},
 		"jest-matcher-utils": {
 			"version": "22.4.3",
-			"resolved": "http://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"jest-get-type": "22.4.3",
@@ -8068,12 +8476,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"pretty-format": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0",
 						"ansi-styles": "3.2.1"
@@ -8099,7 +8509,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8195,7 +8605,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8346,7 +8756,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8448,7 +8858,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "1.0.0"
@@ -8559,7 +8969,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8636,7 +9046,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8671,7 +9081,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -8726,10 +9136,22 @@
 				"topo": "3.0.0"
 			}
 		},
+		"jpeg-js": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
+			"integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
+			"dev": true
+		},
 		"js-base64": {
 			"version": "2.4.9",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
 			"integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
+		},
+		"js-library-detector": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-4.3.1.tgz",
+			"integrity": "sha1-bTT1UAKBO8CnVD3u9T+qTi55dns=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -8807,7 +9229,8 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -8820,7 +9243,8 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -8865,6 +9289,7 @@
 			"version": "9.8.7",
 			"resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
 			"integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
+			"dev": true,
 			"requires": {
 				"is-in-browser": "1.1.3",
 				"symbol-observable": "1.2.0",
@@ -8874,12 +9299,14 @@
 				"symbol-observable": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+					"dev": true
 				},
 				"warning": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -8890,6 +9317,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
 			"integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+			"dev": true,
 			"requires": {
 				"hyphenate-style-name": "1.0.2"
 			}
@@ -8898,6 +9326,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
 			"integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+			"dev": true,
 			"requires": {
 				"warning": "3.0.0"
 			},
@@ -8906,6 +9335,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -8915,17 +9345,20 @@
 		"jss-default-unit": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-			"integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+			"integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+			"dev": true
 		},
 		"jss-expand": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.3.0.tgz",
-			"integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg=="
+			"integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg==",
+			"dev": true
 		},
 		"jss-extend": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
 			"integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
+			"dev": true,
 			"requires": {
 				"warning": "3.0.0"
 			},
@@ -8934,6 +9367,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -8943,12 +9377,14 @@
 		"jss-global": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-			"integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+			"integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+			"dev": true
 		},
 		"jss-nested": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
 			"integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+			"dev": true,
 			"requires": {
 				"warning": "3.0.0"
 			},
@@ -8957,6 +9393,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -8967,6 +9404,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.5.0.tgz",
 			"integrity": "sha512-qZbpRVtHT7hBPpZEBPFfafZKWmq3tA/An5RNqywDsZQGrlinIF/mGD9lmj6jGqu8GrED2SMHZ3pPKLmjCZoiaQ==",
+			"dev": true,
 			"requires": {
 				"jss-camel-case": "6.1.0",
 				"jss-compose": "5.0.0",
@@ -8983,12 +9421,14 @@
 		"jss-props-sort": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-			"integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+			"integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+			"dev": true
 		},
 		"jss-template": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
 			"integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
+			"dev": true,
 			"requires": {
 				"warning": "3.0.0"
 			},
@@ -8997,6 +9437,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -9007,6 +9448,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
 			"integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+			"dev": true,
 			"requires": {
 				"css-vendor": "0.3.8"
 			}
@@ -9019,7 +9461,8 @@
 		"keycode": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
+			"dev": true
 		},
 		"killable": {
 			"version": "1.0.1",
@@ -9075,6 +9518,128 @@
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
+			}
+		},
+		"lighthouse": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-3.1.1.tgz",
+			"integrity": "sha512-NymmSnG9z+6DL+FZf1dJhdeZKvf+s8txVlQF5LafYBcBWMjmQQk0kR1pSl0lP5RNuuxiXH4KU29uJUKSjxyejg==",
+			"dev": true,
+			"requires": {
+				"axe-core": "3.0.0-beta.2",
+				"chrome-devtools-frontend": "1.0.422034",
+				"chrome-launcher": "0.10.2",
+				"configstore": "3.1.2",
+				"devtools-timeline-model": "1.1.6",
+				"esprima": "4.0.1",
+				"http-link-header": "0.8.0",
+				"inquirer": "3.3.0",
+				"intl-messageformat": "2.2.0",
+				"intl-messageformat-parser": "1.4.0",
+				"jpeg-js": "0.1.2",
+				"js-library-detector": "4.3.1",
+				"lighthouse-logger": "1.1.0",
+				"lodash.isequal": "4.5.0",
+				"lookup-closest-locale": "6.0.4",
+				"metaviewport-parser": "0.2.0",
+				"mkdirp": "0.5.1",
+				"opn": "4.0.2",
+				"parse-cache-control": "1.0.1",
+				"raven": "2.6.4",
+				"rimraf": "2.6.2",
+				"robots-parser": "2.1.0",
+				"semver": "5.5.1",
+				"speedline-core": "1.4.0",
+				"update-notifier": "2.5.0",
+				"ws": "3.3.2",
+				"yargs": "3.32.0",
+				"yargs-parser": "7.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"opn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+					"dev": true,
+					"requires": {
+						"object-assign": "4.1.1",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"dev": true,
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"window-size": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+					"dev": true
+				},
+				"ws": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+					"integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "1.0.0",
+						"safe-buffer": "5.1.2",
+						"ultron": "1.1.1"
+					}
+				},
+				"yargs": {
+					"version": "3.32.0",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+					"dev": true,
+					"requires": {
+						"camelcase": "2.1.1",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"os-locale": "1.4.0",
+						"string-width": "1.0.2",
+						"window-size": "0.1.4",
+						"y18n": "3.2.1"
+					}
+				}
+			}
+		},
+		"lighthouse-logger": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.1.0.tgz",
+			"integrity": "sha512-l5/HppTtadQ9jyz6CoFPzEr/0zsr6tKL8e4wDBSlKDeaH5PZtI/Z/9YflLrds+uOhC3rk7xWCjIXqqhAjaQ+oA==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"marky": "1.2.0"
 			}
 		},
 		"load-json-file": {
@@ -9176,12 +9741,14 @@
 		"lodash-es": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
+			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
+			"dev": true
 		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -9196,7 +9763,8 @@
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
 		},
 		"lodash.cond": {
 			"version": "4.5.2",
@@ -9221,27 +9789,38 @@
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lodash.keys": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
 			"requires": {
 				"lodash._getnative": "3.9.1",
 				"lodash.isarguments": "3.1.0",
@@ -9261,17 +9840,20 @@
 		"lodash.pick": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+			"dev": true
 		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"lodash.template": {
 			"version": "4.4.0",
@@ -9293,12 +9875,14 @@
 		"lodash.throttle": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
 		},
 		"lodash.topath": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-			"integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak="
+			"integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
+			"dev": true
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
@@ -9314,6 +9898,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
 			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"lookup-closest-locale": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.0.4.tgz",
+			"integrity": "sha512-bWoFbSGe6f1GvMGzj17LrwMX4FhDXDwZyH04ySVCPbtOJADcSRguZNKewoJ3Ful/MOxD/wRHvFPadk/kYZUbuQ==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -9369,7 +9959,8 @@
 		"make-error": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"dev": true
 		},
 		"makeerror": {
 			"version": "1.0.11",
@@ -9389,6 +9980,11 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
+		"map-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9401,6 +9997,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.2.tgz",
 			"integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
 				"marked": "0.3.19"
@@ -9409,7 +10006,14 @@
 		"marked": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+			"dev": true
+		},
+		"marky": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.0.tgz",
+			"integrity": "sha1-lhftZHu76o9F0ZUm2jPexwYG30I=",
+			"dev": true
 		},
 		"math-expression-evaluator": {
 			"version": "1.2.17",
@@ -9420,6 +10024,17 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "1.1.6"
+			}
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -9451,6 +10066,11 @@
 				"errno": "0.1.7",
 				"readable-stream": "2.3.6"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
 		},
 		"meow": {
 			"version": "3.7.0",
@@ -9500,7 +10120,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
@@ -9585,6 +10205,12 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"metaviewport-parser": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
+			"integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE=",
+			"dev": true
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9653,6 +10279,7 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"dev": true,
 			"requires": {
 				"dom-walk": "0.1.1"
 			}
@@ -9677,13 +10304,14 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "1.6.2",
 				"duplexify": "3.6.0",
@@ -9718,7 +10346,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -9728,6 +10356,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
 				"copy-concurrently": "1.0.5",
@@ -9740,7 +10369,8 @@
 		"mri": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.1.tgz",
-			"integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE="
+			"integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE=",
+			"dev": true
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -9764,7 +10394,8 @@
 		"mutationobserver-shim": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
-			"integrity": "sha1-9NXa56SXGiIHkU+1qQ69UUtlrMo="
+			"integrity": "sha1-9NXa56SXGiIHkU+1qQ69UUtlrMo=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -9860,6 +10491,7 @@
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
 			"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+			"dev": true,
 			"requires": {
 				"minimatch": "3.0.4"
 			}
@@ -9968,7 +10600,8 @@
 		"normalize-scroll-left": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
-			"integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+			"integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==",
+			"dev": true
 		},
 		"normalize-url": {
 			"version": "1.9.1",
@@ -9992,6 +10625,70 @@
 				}
 			}
 		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
+				"memorystream": "0.3.1",
+				"minimatch": "3.0.4",
+				"ps-tree": "1.1.0",
+				"read-pkg": "3.0.0",
+				"shell-quote": "1.6.1",
+				"string.prototype.padend": "3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"requires": {
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.5.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"requires": {
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
+					}
+				}
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10004,6 +10701,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
 				"are-we-there-yet": "1.1.5",
 				"console-control-strings": "1.1.0",
@@ -10086,6 +10784,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -10097,6 +10796,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-1.0.0.tgz",
 			"integrity": "sha512-F7XUm84lg0uNXNzrRAC5q8KJe0yYaxgLU9hTSqWYM6Rfnh0YjP24EG3xq7ncj2Wu1AdfueNHKCOlamIonG4UHQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -10108,6 +10808,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0"
@@ -10134,6 +10835,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -10296,6 +10998,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
 			"requires": {
 				"cyclist": "0.2.2",
 				"inherits": "2.0.3",
@@ -10321,6 +11024,12 @@
 				"evp_bytestokey": "1.0.3",
 				"pbkdf2": "3.0.16"
 			}
+		},
+		"parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -10425,6 +11134,14 @@
 				"pify": "2.3.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
 		"pbkdf2": {
 			"version": "3.0.16",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
@@ -10476,7 +11193,8 @@
 		"popper.js": {
 			"version": "1.14.4",
 			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
-			"integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
+			"integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY=",
+			"dev": true
 		},
 		"portfinder": {
 			"version": "1.0.17",
@@ -10527,7 +11245,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10592,7 +11310,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10656,7 +11374,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10719,7 +11437,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10782,7 +11500,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10845,7 +11563,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10908,7 +11626,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -10972,7 +11690,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11035,7 +11753,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11087,6 +11805,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.3.1.tgz",
 			"integrity": "sha512-9y9kDDf2F9EjKX6x9ueNa5GARvsUbXw4ezH8vXItXHwKzljbu8awP7t5dCaabKYm18Vs1lo5bKQcnc0HkISt+w==",
+			"dev": true,
 			"requires": {
 				"postcss": "6.0.23"
 			}
@@ -11095,6 +11814,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
 			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"dev": true,
 			"requires": {
 				"cosmiconfig": "4.0.0",
 				"import-cwd": "2.1.0"
@@ -11125,7 +11845,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
@@ -11168,7 +11888,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
@@ -11190,6 +11910,7 @@
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
 			"integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
 				"postcss": "6.0.23",
@@ -11214,7 +11935,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11277,7 +11998,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11353,7 +12074,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11423,7 +12144,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11487,7 +12208,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11553,7 +12274,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11619,7 +12340,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11717,7 +12438,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11783,7 +12504,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11847,7 +12568,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11911,7 +12632,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -11974,7 +12695,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12039,7 +12760,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12115,7 +12836,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12180,7 +12901,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12250,7 +12971,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12316,7 +13037,8 @@
 		"prettier": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
-			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg=="
+			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "4.0.2",
@@ -12336,6 +13058,7 @@
 			"version": "23.6.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
 			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "3.0.0",
 				"ansi-styles": "3.2.1"
@@ -12344,7 +13067,8 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				}
 			}
 		},
@@ -12352,6 +13076,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.6.0.tgz",
 			"integrity": "sha512-bnCmsPy98ERD7VWBO+0y1OGWLfx/DPUjNFN2ZRVyxuGBiic1BXAGgjHsTKgBIbPISdqpP6KBEmRV0Lir4xu/BA==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"execa": "0.8.0",
@@ -12364,6 +13089,7 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -12384,7 +13110,8 @@
 		"process": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -12407,12 +13134,14 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
 		},
 		"promise.prototype.finally": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
 			"integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -12447,6 +13176,14 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"requires": {
+				"event-stream": "3.3.6"
+			}
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -12473,6 +13210,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"once": "1.4.0"
@@ -12482,6 +13220,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
 			"requires": {
 				"duplexify": "3.6.0",
 				"inherits": "2.0.3",
@@ -12532,6 +13271,7 @@
 			"version": "0.19.6",
 			"resolved": "https://registry.npmjs.org/radium/-/radium-0.19.6.tgz",
 			"integrity": "sha512-IABYntqCwYelUUIwA52maSCgJbqtJjHKIoD21wgpw3dGhIUbJ5chDShDGdaFiEzdF03hN9jfQqlmn0bF4YhfrQ==",
+			"dev": true,
 			"requires": {
 				"array-find": "1.0.0",
 				"exenv": "1.2.2",
@@ -12541,8 +13281,9 @@
 			"dependencies": {
 				"inline-style-prefixer": {
 					"version": "2.0.5",
-					"resolved": "http://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+					"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
 					"integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
+					"dev": true,
 					"requires": {
 						"bowser": "1.9.4",
 						"hyphenate-style-name": "1.0.2"
@@ -12602,6 +13343,19 @@
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
+		"raven": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+			"integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
+			"dev": true,
+			"requires": {
+				"cookie": "0.3.1",
+				"md5": "2.2.1",
+				"stack-trace": "0.0.10",
+				"timed-out": "4.0.1",
+				"uuid": "3.3.2"
+			}
+		},
 		"raw-body": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
@@ -12654,7 +13408,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -12686,6 +13440,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/react-app-rewire-graphql-tag/-/react-app-rewire-graphql-tag-1.1.0.tgz",
 			"integrity": "sha512-BihgQj9jF1qCZcgmlFl7qnPI4ZoCIg7eJZGUz8OXg9Geyh91MBRTv7mScz1S8Dt9qx/3VuEnWQjW6NaLwrQp1g==",
+			"dev": true,
 			"requires": {
 				"graphql-tag": "2.9.2"
 			}
@@ -12694,6 +13449,7 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-1.6.2.tgz",
 			"integrity": "sha512-TxbP1W9jPPTmj0YJeFNgcJc6IMg7sv845aHUIUvVQtXdA8IWzOZairk3Bth6GHbxoF2QitbvUlM7/NAH4VmmJg==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"dotenv": "4.0.0"
@@ -12702,7 +13458,8 @@
 				"dotenv": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-					"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+					"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+					"dev": true
 				}
 			}
 		},
@@ -12738,7 +13495,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -12759,6 +13516,7 @@
 			"version": "3.0.0-rc.1",
 			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-rc.1.tgz",
 			"integrity": "sha512-jOnu9qEqNlBx5Jrgx8mcHmG6FQcrBIpdZ5HTcZqW5hOkYsmCAPID0vEm66mkVbh3anli9+WWK2wL3AKK1ivNBA==",
+			"dev": true,
 			"requires": {
 				"@babel/parser": "7.0.0-beta.53",
 				"async": "2.6.1",
@@ -12789,6 +13547,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.3.tgz",
 			"integrity": "sha512-21ubz0vpzPL/8YPGkcDs/LFIemxMFPhpXnFKvrm15IA7x/kYzh1Bru3ww/lsZJJ0hCqyhJGjv7Txl/U00Je5SA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "7.0.0-rc.1",
 				"prop-types": "15.6.2",
@@ -12799,6 +13558,7 @@
 					"version": "7.0.0-rc.1",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.1.tgz",
 					"integrity": "sha512-Nifv2kwP/nwR39cAOasNxzjYfpeuf/ZbZNtQz5eYxWTC9yHARU9wItFnAwz1GTZ62MU+AtSjzZPMbLK5Q9hmbg==",
+					"dev": true,
 					"requires": {
 						"regenerator-runtime": "0.12.1"
 					}
@@ -12808,12 +13568,14 @@
 		"react-fast-compare": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-1.0.0.tgz",
-			"integrity": "sha512-dcQpdWr62flXQJuM8/bVEY5/10ad2SYBUafp8H4q4WHR3fTA/MMlp8mpzX12I0CCoEJc1P6QdiMg7U+7lFS6Rw=="
+			"integrity": "sha512-dcQpdWr62flXQJuM8/bVEY5/10ad2SYBUafp8H4q4WHR3fTA/MMlp8mpzX12I0CCoEJc1P6QdiMg7U+7lFS6Rw==",
+			"dev": true
 		},
 		"react-fuzzy": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
 			"integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"classnames": "2.2.6",
@@ -12825,6 +13587,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.3.tgz",
 			"integrity": "sha1-jDbDX85rdQk40oavQo7R2nYlGG4=",
+			"dev": true,
 			"requires": {
 				"html-element-attributes": "1.3.1"
 			}
@@ -12832,12 +13595,14 @@
 		"react-icon-base": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
-			"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50="
+			"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
+			"dev": true
 		},
 		"react-icons": {
 			"version": "2.2.7",
 			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
 			"integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+			"dev": true,
 			"requires": {
 				"react-icon-base": "2.1.0"
 			}
@@ -12846,6 +13611,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.0.tgz",
 			"integrity": "sha512-aIcbWb0fKFhEMB+RadoOYawlr1JoMMfrQ1oRgPUG/f/e4zERVJ6nYcIaQmrQmdHCZ63BOqe2cEkoeY0kyLBzNg==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"is-dom": "1.0.9"
@@ -12855,6 +13621,7 @@
 			"version": "8.6.1",
 			"resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.6.1.tgz",
 			"integrity": "sha512-SH6XrJDJkAphp602J14JTy3puB2Zxz1FkM3bKVE8wON+va99jnUTKWnzGECb3NfIn9JPR5vHykge7K3/A747xQ==",
+			"dev": true,
 			"requires": {
 				"hoist-non-react-statics": "2.5.5",
 				"jss": "9.8.7",
@@ -12880,6 +13647,7 @@
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
 			"integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
+			"dev": true,
 			"requires": {
 				"exenv": "1.2.2",
 				"prop-types": "15.6.2",
@@ -12891,6 +13659,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.4.0"
 					}
@@ -13025,7 +13794,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "2.2.1",
@@ -13310,7 +14079,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
@@ -13464,6 +14233,7 @@
 			"version": "0.1.84",
 			"resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.84.tgz",
 			"integrity": "sha512-rso1dRAXX/WETyqF5C0fomIYzpF71Nothfr1R7pFkrJCPVJ20ok2e6wqF+JvUTyE/meiBvsbNPT1loZjyU+53w==",
+			"dev": true,
 			"requires": {
 				"inline-style-prefixer": "3.0.8",
 				"prop-types": "15.6.2",
@@ -13475,6 +14245,7 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
 			"integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
+			"dev": true,
 			"requires": {
 				"prop-types": "15.6.2"
 			}
@@ -13483,6 +14254,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-4.1.9.tgz",
 			"integrity": "sha512-RBttOeFQg/p+PRc7CTcTxI9fmRwed8q6rdU1gaforp2hB899X0M6hL4vBfjJ8Vmova6juM9jTuR5x6/wbqOv9g==",
+			"dev": true,
 			"requires": {
 				"dom-testing-library": "3.5.1",
 				"wait-for-expect": "1.0.0"
@@ -13492,6 +14264,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
 			"integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+			"dev": true,
 			"requires": {
 				"dom-helpers": "3.3.1",
 				"loose-envify": "1.4.0",
@@ -13503,6 +14276,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/react-treebeard/-/react-treebeard-2.1.0.tgz",
 			"integrity": "sha512-unoy8IJL1NR5jgTtK+CqOCZKZylh/Tlid0oYajW9bLZCbFelxzmCsF8Y2hyS6pvHqM4W501oOm5O/jvg3VZCrg==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"deep-equal": "1.0.1",
@@ -13560,6 +14334,7 @@
 			"version": "0.15.4",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.15.4.tgz",
 			"integrity": "sha512-f/aiWt9K8Wtbmak6Gg3vt90pQQgYK5OyL3CC33KAA2qXFHGfo5C6b3x8xmyNv4+S4v6eLfgD2VOL7qFRfhMxJA==",
+			"dev": true,
 			"requires": {
 				"ast-types": "0.11.5",
 				"esprima": "4.0.1",
@@ -13570,7 +14345,8 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				}
 			}
 		},
@@ -13578,6 +14354,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.8.1"
 			}
@@ -13586,6 +14363,7 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
 			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "7.0.0",
 				"change-emitter": "0.1.6",
@@ -13617,6 +14395,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"dev": true,
 			"requires": {
 				"indent-string": "3.2.0",
 				"strip-indent": "2.0.0"
@@ -13644,6 +14423,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.10",
 				"lodash-es": "4.17.10",
@@ -13692,6 +14472,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
 			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3"
 			}
@@ -13699,7 +14480,8 @@
 		"regexpp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"dev": true
 		},
 		"regexpu-core": {
 			"version": "1.0.0",
@@ -13823,7 +14605,8 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
@@ -13935,6 +14718,12 @@
 				"inherits": "2.0.3"
 			}
 		},
+		"robots-parser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.0.tgz",
+			"integrity": "sha512-k07MeDS1Tl1zjoYs5bHfUbgQ0MfaeTOepDcjZFxdYXd84p6IeLDQyUwlMk2AZ9c2yExA30I3ayWhmqz9tg0DzQ==",
+			"dev": true
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -13947,6 +14736,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
 			"requires": {
 				"aproba": "1.2.0"
 			}
@@ -14095,7 +14885,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -14117,6 +14907,7 @@
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+			"dev": true,
 			"requires": {
 				"ajv": "6.5.3",
 				"ajv-keywords": "3.2.0"
@@ -14171,12 +14962,30 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+			"dev": true
+		},
+		"serve": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/serve/-/serve-10.0.0.tgz",
+			"integrity": "sha512-S9q9cIVeaT78DVk70/JWubco89P5KXIR5IEuVz83YUfvUaqQ7cpVw62eGZsA/ftaTZNmAkQnqn2mBMx+NDLN3A==",
+			"dev": true,
+			"requires": {
+				"@zeit/schemas": "2.1.1",
+				"ajv": "6.5.3",
+				"arg": "2.0.0",
+				"boxen": "1.3.0",
+				"chalk": "2.4.1",
+				"clipboardy": "1.2.3",
+				"serve-handler": "5.0.0",
+				"update-check": "1.5.2"
+			}
 		},
 		"serve-favicon": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
 			"integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
+			"dev": true,
 			"requires": {
 				"etag": "1.8.1",
 				"fresh": "0.5.2",
@@ -14188,12 +14997,54 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"dev": true
+				}
+			}
+		},
+		"serve-handler": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-5.0.0.tgz",
+			"integrity": "sha512-VbNr1Yk4cDMAdIyVr5J1vPtGuXUsuu0R8iht+reK0g8t48fSuGWqnsIYVh3xXFJynFDHMLbPQ9mll+/hhmuGEQ==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.0.0",
+				"content-disposition": "0.5.2",
+				"fast-url-parser": "1.1.3",
+				"glob-slash": "1.0.0",
+				"mime-types": "2.1.18",
+				"minimatch": "3.0.4",
+				"path-is-inside": "1.0.2",
+				"path-to-regexp": "2.2.1",
+				"range-parser": "1.2.0"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.33.0"
+					}
+				},
+				"path-to-regexp": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+					"integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -14281,6 +15132,7 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
 			"integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
+			"dev": true,
 			"requires": {
 				"lodash.keys": "3.1.2"
 			}
@@ -14313,6 +15165,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.3",
 				"interpret": "1.1.0",
@@ -14601,6 +15454,25 @@
 				"wbuf": "1.7.3"
 			}
 		},
+		"speedline-core": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.0.tgz",
+			"integrity": "sha512-GEUB8IZCV8fXF2ZIekwg0HkI/3HnALfysw3nPsVMBPoZHwD8eT53pIzCZ6qBR7gU3VFadjmKAWT9w0Cvqp2MXQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "9.6.31",
+				"image-ssim": "0.2.0",
+				"jpeg-js": "0.1.2"
+			}
+		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14634,9 +15506,16 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
 			}
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -14671,10 +15550,20 @@
 				"readable-stream": "2.3.6"
 			}
 		},
+		"stream-combiner": {
+			"version": "0.2.2",
+			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+			"requires": {
+				"duplexer": "0.1.1",
+				"through": "2.3.8"
+			}
+		},
 		"stream-each": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"stream-shift": "1.0.0"
@@ -14695,7 +15584,8 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -14724,6 +15614,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.0.tgz",
 			"integrity": "sha512-/g0YW/cEfXASRHAaLR7VZbTUlxgP14fmCsfSRFG2gvlG2S1q9rBpjYnEy/EIIzY+bjzs2nTfAHJYXmQ+zTnXSQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -14746,6 +15637,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
 			"integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
 				"es-abstract": "1.12.0",
@@ -14781,7 +15673,8 @@
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -14792,6 +15685,7 @@
 			"version": "0.20.3",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
 			"integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
 				"schema-utils": "0.4.7"
@@ -14808,7 +15702,8 @@
 		"svg-tag-names": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.1.tgz",
-			"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo="
+			"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo=",
+			"dev": true
 		},
 		"svgo": {
 			"version": "0.7.2",
@@ -14905,6 +15800,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.0.tgz",
 			"integrity": "sha512-I9mrbZ5M96s7QeJDv95toF1svkUjeBybe8ydhY7foPaBmr0SPJMFupArmMkDrOKTTj0sJVr+nvQNxWLziQ7nDQ==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "1.0.0"
 			}
@@ -15169,6 +16065,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
 			"integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+			"dev": true,
 			"requires": {
 				"brcast": "3.0.1",
 				"is-function": "1.0.1",
@@ -15190,6 +16087,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.6",
 				"xtend": "4.0.1"
@@ -15316,7 +16214,8 @@
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -15381,7 +16280,7 @@
 				},
 				"yargs": {
 					"version": "3.10.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"requires": {
 						"camelcase": "1.2.1",
@@ -15402,6 +16301,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
 			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
+			"dev": true,
 			"requires": {
 				"cacache": "10.0.4",
 				"find-cache-dir": "1.0.0",
@@ -15416,18 +16316,26 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
 				},
 				"uglify-es": {
 					"version": "3.3.9",
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"dev": true,
 					"requires": {
 						"commander": "2.13.0",
 						"source-map": "0.6.1"
 					}
 				}
 			}
+		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+			"dev": true
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -15475,6 +16383,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"dev": true,
 			"requires": {
 				"unique-slug": "2.0.0"
 			}
@@ -15483,6 +16392,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "0.1.4"
 			}
@@ -15551,6 +16461,16 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
 			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
 		},
+		"update-check": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
+			"integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
+			"dev": true,
+			"requires": {
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0"
+			}
+		},
 		"update-notifier": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
@@ -15577,6 +16497,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "2.1.1"
 			}
@@ -15715,12 +16636,14 @@
 		"velocity-animate": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.2.tgz",
-			"integrity": "sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg=="
+			"integrity": "sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==",
+			"dev": true
 		},
 		"velocity-react": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
 			"integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.10",
 				"prop-types": "15.6.2",
@@ -15813,7 +16736,8 @@
 		"wait-for-expect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.0.0.tgz",
-			"integrity": "sha512-I6OlPKnd4qVdKJf1Gjx9M9qQjIk29rALoUkjwIKa9pNDCdzUuJTfaNv1mtsm2QdSvF0ZQogrWJMifTN1lUeXig=="
+			"integrity": "sha512-I6OlPKnd4qVdKJf1Gjx9M9qQjIk29rALoUkjwIKa9pNDCdzUuJTfaNv1mtsm2QdSvF0ZQogrWJMifTN1lUeXig==",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
@@ -15863,6 +16787,7 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
 			"integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.7.3",
 				"acorn-dynamic-import": "2.0.2",
@@ -15891,17 +16816,20 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -15910,6 +16838,7 @@
 					"version": "0.4.6",
 					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7",
 						"uglify-js": "2.8.29",
@@ -16166,7 +17095,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "1.0.0"
@@ -16275,7 +17204,7 @@
 				},
 				"yargs": {
 					"version": "6.6.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
 						"camelcase": "3.0.0",
@@ -16307,6 +17236,7 @@
 			"version": "2.23.1",
 			"resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.23.1.tgz",
 			"integrity": "sha512-oUdCGDHONJrARtqxPSiON4db4dRWUsRiPwD7dYkglrTc3vF7LKa2jncwN0lIVkNwtoCh/yiHVTzz3Hbcux8ikA==",
+			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"html-entities": "1.2.1",
@@ -16337,7 +17267,7 @@
 				},
 				"jsonfile": {
 					"version": "2.4.0",
-					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"requires": {
 						"graceful-fs": "4.1.11"
@@ -16429,6 +17359,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2"
 			}
@@ -16490,7 +17421,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "1.0.2",
@@ -16647,9 +17578,9 @@
 			}
 		},
 		"yup": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/yup/-/yup-0.26.3.tgz",
-			"integrity": "sha512-Jg8fLV+ax2E5kHtAFAvh/JzMnpgyQykZS1DG8NAqojzsLjfSWKi1fX6VxHkYuQyyqPcH4bvStTBX/aF5CFhv4Q==",
+			"version": "0.26.5",
+			"resolved": "https://registry.npmjs.org/yup/-/yup-0.26.5.tgz",
+			"integrity": "sha512-fBf7pfOCoGgk6ppcRkR5UjVxBqTHM/4d4WCrJN5fa7vFJFwM3f3tQYKY5cLSks2k8FixPW+WO7HGSPKoJCxbZw==",
 			"requires": {
 				"@babel/runtime": "7.0.0",
 				"fn-name": "2.0.1",

--- a/packages/titus-kitchen-sink/package.json
+++ b/packages/titus-kitchen-sink/package.json
@@ -27,7 +27,7 @@
     "reselect": "^3.0.1",
     "sillyname": "^0.1.0",
     "victory": "^0.27.0",
-    "yup": "^0.26.3"
+    "yup": "^0.26.5"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -40,7 +40,8 @@
     "commit-check": "pretty-quick --staged",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",
-    "format": "prettier --write *.js **/*.js"
+    "format": "prettier --write *.js **/*.js",
+    "lighthouse": "node lighthouse"
   },
   "devDependencies": {
     "@material-ui/core": "^3.0.1",
@@ -59,13 +60,15 @@
     "eslint-plugin-import": "^2.6.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.1.0",
-    "formik": "^1.0.1",
+    "formik": "^1.3.0",
     "husky": "^0.14.3",
     "jest-dom": "^1.8.1",
+    "lighthouse": "^3.1.1",
     "prettier": "1.14.2",
     "pretty-quick": "^1.6.0",
     "react-app-rewire-graphql-tag": "^1.1.0",
     "react-app-rewired": "^1.6.2",
-    "react-testing-library": "^4.1.2"
+    "react-testing-library": "^4.1.2",
+    "serve": "^10.0.0"
   }
 }

--- a/packages/titus-kitchen-sink/public/manifest.json
+++ b/packages/titus-kitchen-sink/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "titus-kitchen-sink",
+  "name": "Titus Kitchen Sink",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
Addresses #140 

This PR introduces lighthouse report generation by:

- building the kitchen-sink app and persisting the bundle to the circle workspace
- introduce a new lighthouse job which:
  - starts a static server to serve the built app
  - runs lighthouse programmatically against it
  - generates an html report
- publish the lighthouse report as an artifact so it's available on circle

Example: https://951-135312557-gh.circle-artifacts.com/0/titus-kitchen-sink-lighthouse-report.html

There are a few shortcomings to this approach when it comes to tuning the app to get a better score:

- running lighthouse against titus.nearform.com gives entirely different results, meaning that it's not easy to decide what to tune to get a better score, because it really feels like the results during the CI run are fake
- running lighthouse against titus is inherently flawed, because it will only possibly test the login page

Better than nothing though!