### PR TITLE
Temporal tables

### DIFF
--- a/packages/titus-kitchen-sink-backend/docker/db/initdb/versioning_function_nochecks.sql
+++ b/packages/titus-kitchen-sink-backend/docker/db/initdb/versioning_function_nochecks.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION versioning()
+RETURNS TRIGGER AS $$
+DECLARE
+  sys_period text;
+  history_table text;
+  manipulate jsonb;
+  commonColumns text[];
+  time_stamp_to_use timestamptz := current_timestamp;
+  range_lower timestamptz;
+  transaction_info txid_snapshot;
+  existing_range tstzrange;
+BEGIN
+  -- version 0.0.1
+
+  sys_period := TG_ARGV[0];
+  history_table := TG_ARGV[1];
+
+  IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+    -- Ignore rows already modified in this transaction
+    transaction_info := txid_current_snapshot();
+    IF OLD.xmin::text >= (txid_snapshot_xmin(transaction_info) % (2^32)::bigint)::text
+    AND OLD.xmin::text <= (txid_snapshot_xmax(transaction_info) % (2^32)::bigint)::text THEN
+      IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    EXECUTE format('SELECT $1.%I', sys_period) USING OLD INTO existing_range;
+
+    IF TG_ARGV[2] = 'true' THEN
+      -- mitigate update conflicts
+      range_lower := lower(existing_range);
+      IF range_lower >= time_stamp_to_use THEN
+        time_stamp_to_use := range_lower + interval '1 microseconds';
+      END IF;
+    END IF;
+
+    WITH history AS
+      (SELECT attname
+      FROM   pg_attribute
+      WHERE  attrelid = history_table::regclass
+      AND    attnum > 0
+      AND    NOT attisdropped),
+      main AS
+      (SELECT attname
+      FROM   pg_attribute
+      WHERE  attrelid = TG_RELID
+      AND    attnum > 0
+      AND    NOT attisdropped)
+    SELECT array_agg(quote_ident(history.attname)) INTO commonColumns
+      FROM history
+      INNER JOIN main
+      ON history.attname = main.attname
+      AND history.attname != sys_period;
+
+    EXECUTE ('INSERT INTO ' ||
+      CASE split_part(history_table, '.', 2)
+      WHEN '' THEN
+        quote_ident(history_table)
+      ELSE
+        quote_ident(split_part(history_table, '.', 1)) || '.' || quote_ident(split_part(history_table, '.', 2))
+      END ||
+      '(' ||
+      array_to_string(commonColumns , ',') ||
+      ',' ||
+      quote_ident(sys_period) ||
+      ') VALUES ($1.' ||
+      array_to_string(commonColumns, ',$1.') ||
+      ',tstzrange($2, $3, ''[)''))')
+       USING OLD, range_lower, time_stamp_to_use;
+  END IF;
+
+  IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
+    manipulate := jsonb_set('{}'::jsonb, ('{' || sys_period || '}')::text[], to_jsonb(tstzrange(time_stamp_to_use, null, '[)')));
+
+    RETURN jsonb_populate_record(NEW, manipulate);
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/titus-kitchen-sink-backend/lib/graphql/model/foodHistory.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/model/foodHistory.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const formatRows = require('./util').formatRows
+const SQL = require('@nearform/sql')
+
+const findByFoodId = async (pg, { id }) => {
+  const res = await pg.query(SQL`
+    SELECT id, name, food_group_id, created, modified, sys_period FROM food_history WHERE id = ${id}`)
+
+  return formatRows(res.rows)
+}
+
+module.exports = {
+  findByFoodId
+}

--- a/packages/titus-kitchen-sink-backend/lib/graphql/resolver/foodHistory.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/resolver/foodHistory.js
@@ -1,0 +1,17 @@
+'use strict'
+const foodHistory = require('../model/foodHistory')
+
+const resolvers = {
+  Query: {
+    foodHistory (root, args, context) {
+      return foodHistory.findByFoodId(context.pg, args)
+    }
+  },
+  FoodHistory: {
+    foodGroup (root, args, context) {
+      return context.loaders.foodGroup.getById.load(root.foodGroupId)
+    }
+  }
+}
+
+module.exports = resolvers

--- a/packages/titus-kitchen-sink-backend/lib/graphql/resolver/index.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/resolver/index.js
@@ -1,7 +1,8 @@
 'use strict'
 const food = require('./food')
+const foodHistory = require('./foodHistory')
 const foodGroup = require('./foodGroup')
 const dietType = require('./dietType')
 const scalars = require('./scalars')
 
-module.exports = [food, foodGroup, dietType, scalars]
+module.exports = [food, foodHistory, foodGroup, dietType, scalars]

--- a/packages/titus-kitchen-sink-backend/lib/graphql/schema/foodHistory.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/schema/foodHistory.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const foodHistory = `
+type FoodHistory {
+    id: ID!
+    name: String!
+    created: Date!
+    modified: Date,
+    sysPeriod: Range!,
+    foodGroup: FoodGroup!
+  }
+
+type Range {
+  begin: Date!,
+  end: Date!
+}
+`
+
+module.exports = [foodHistory]

--- a/packages/titus-kitchen-sink-backend/lib/graphql/schema/index.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/schema/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const food = require('./food')
+const foodHistory = require('./foodHistory')
 const foodGroup = require('./foodGroup')
 const dietType = require('./dietType')
 const query = require('./query')
@@ -12,6 +13,7 @@ const schema = [].concat(
   query,
   mutation,
   food,
+  foodHistory,
   foodGroup,
   dietType,
   scalars,

--- a/packages/titus-kitchen-sink-backend/lib/graphql/schema/query.js
+++ b/packages/titus-kitchen-sink-backend/lib/graphql/schema/query.js
@@ -3,6 +3,7 @@
 const query = `
 type Query {
   food(id: ID): Food
+  foodHistory(id: ID!): [FoodHistory]
   search(needle: String, type: String): [Food]
   keywordSearch(needle: String, type: String): [KeywordSearchResult]
   allFood(offset: Int, limit: Int): [Food]

--- a/packages/titus-kitchen-sink-backend/lib/pg-plugin.js
+++ b/packages/titus-kitchen-sink-backend/lib/pg-plugin.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const PgPool = require('pg-pool')
+const pg = require('pg')
+require('pg-range').install(pg)
 
 const pluginName = 'pgPlugin'
 
@@ -23,6 +25,7 @@ module.exports = {
 
         server.logger().debug('Getting database connection')
         request.pg = await pool.connect()
+
         if (isTransactional(request)) {
           server.logger().debug('Begin transaction')
           await request.pg.query('BEGIN')

--- a/packages/titus-kitchen-sink-backend/package.json
+++ b/packages/titus-kitchen-sink-backend/package.json
@@ -48,6 +48,7 @@
     "node-fetch": "^2.2.0",
     "pg": "^7.4.3",
     "pg-pool": "^2.0.3",
+    "pg-range": "^1.0.0",
     "postgrator": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/titus-kitchen-sink-backend/tools/migrations/build/001.do.create-tables.js
+++ b/packages/titus-kitchen-sink-backend/tools/migrations/build/001.do.create-tables.js
@@ -19,6 +19,14 @@ module.exports.generateSql = function () {
           food_group_id char(36) NOT NULL references food_group(id),
           PRIMARY KEY (id)
       );
+      ALTER TABLE food
+        ADD COLUMN sys_period tstzrange NOT NULL DEFAULT tstzrange(current_timestamp, null);
+      CREATE TABLE food_history (LIKE food);
+      CREATE TRIGGER food_versioning_trigger
+        BEFORE INSERT OR UPDATE OR DELETE ON food
+        FOR EACH ROW EXECUTE PROCEDURE versioning(
+        'sys_period', 'food_history', true
+        );
       CREATE TABLE diet_type
       (
           id char(36) NOT NULL DEFAULT gen_random_uuid(),

--- a/packages/titus-kitchen-sink/src/app.js
+++ b/packages/titus-kitchen-sink/src/app.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import JssProvider from 'react-jss/lib/JssProvider'
 import Loadable from 'react-loadable'
-import ApolloClient from 'apollo-boost'
+import ApolloClient, { InMemoryCache } from 'apollo-boost'
 import { createGenerateClassName, CssBaseline } from '@material-ui/core'
 import { ApolloProvider } from 'react-apollo'
 
@@ -26,6 +26,9 @@ const AsyncLogin = Loadable({
 
 export const apolloClient = new ApolloClient({
   uri: process.env.REACT_APP_GRAPHQL_ENDPOINT,
+  cache: new InMemoryCache({
+    dataIdFromObject: o => o.id ? `${o.__typename}-${o.id}`: null,
+  }),
   request: async operation => {
     operation.setContext({
       headers: {

--- a/packages/titus-kitchen-sink/src/components/temporal/index.js
+++ b/packages/titus-kitchen-sink/src/components/temporal/index.js
@@ -1,0 +1,178 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { Query } from 'react-apollo'
+import { FormControl, Paper, Typography, withStyles } from '@material-ui/core'
+import { Autocomplete, Table } from '@nearform/titus-components'
+import { loadFoodHistoryData } from './queries.graphql'
+import { loadFoodData } from '../api/queries.graphql'
+
+const styles = theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  paperPadding: {
+    padding: theme.spacing.unit * 3,
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  verticalMargin: {
+    marginBottom: theme.spacing.unit * 3
+  },
+  citation: {
+    '& span:first-of-type': {
+      marginTop: theme.spacing.unit * 3
+    }
+  }
+})
+
+const columns = [
+  {
+    accessor: 'name',
+    label: 'Name',
+  },
+  {
+    accessor: 'foodGroup',
+    label: 'Food Group',
+  },
+  {
+    accessor: 'validSince',
+    label: 'Valid Since',
+  },
+  {
+    accessor: 'validUntil',
+    label: 'Valid Until',
+  }
+]
+
+
+class Temporal extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    columns: PropTypes.array.isRequired,
+  }
+
+  static defaultProps = {
+    title: 'Food record history',
+    columns
+  }
+
+  state = {
+    selectedFoodId: ''
+  }
+
+  selectFood = ({key}) => this.setState({selectedFoodId: key})
+
+  render() {
+    const { classes, title, columns } = this.props
+    const { selectedFoodId } = this.state
+
+    return (
+      <div  className={classes.root}>
+        <Typography variant="headline" gutterBottom>
+          Temporal Tables Demo
+        </Typography>
+        <Typography variant="subheading" gutterBottom>
+          This demo shows the <a href="https://github.com/nearform/temporal_tables" target="_blank" rel="noopener noreferrer">temporal tables extension</a> in action. 
+          It track changes to table records.
+        </Typography>
+        <Paper className={classNames(classes.paperPadding, classes.verticalMargin)}>
+          <Query query={loadFoodData}>
+          {({ loading, error, data: { allFood = [] } }) => {
+            if (error) {
+              return (
+                <Typography color="error">
+                  Oops, there was an error requesting the list of foods!
+                </Typography>
+              )
+            }
+
+            const allFoodAutocomplete = allFood.map(({id, name}) => ({key: id, value: name}))
+            
+            return (
+              <React.Fragment>
+                <Paper className={classNames(classes.paperPadding, classes.verticalMargin)}>
+                  <FormControl>
+                    <Autocomplete
+                      placeholder="Find a food by typing its name"
+                      id="food-autocomplete"
+                      data={allFoodAutocomplete}
+                      onChange={this.selectFood}
+                      maxResults={10}
+                      filterType="contains"
+                      loading={loading}
+                    />
+                  </FormControl>
+                </Paper>
+                <Query 
+                  query={loadFoodHistoryData} 
+                  variables={{id: selectedFoodId}} 
+                  skip={!selectedFoodId} 
+                  fetchPolicy="cache-and-network"
+                >
+                {({ error, data: { foodHistory = [] } }) => {
+                  if (error) {
+                    return (
+                      <Typography color="error">
+                        Oops, there was an error requesting the history of food!
+                      </Typography>
+                    )
+                  }
+
+                  if (!selectedFoodId) {
+                    return null
+                  }
+
+                  if (!foodHistory.length) {
+                    return (
+                      <Typography>
+                        The selected food doesn't have any history, try selecting a different food or make some changes to it
+                      </Typography>
+                    )
+                  }
+
+                  const history = foodHistory.map(food => ({
+                    id: food.id,
+                    name: food.name,
+                    foodGroup: food.foodGroup.name,
+                    validSince: new Date(food.sysPeriod.begin).toLocaleString(),
+                    validUntil: new Date(food.sysPeriod.end).toLocaleString(),
+                  }))
+                  
+                  return (  
+                    <React.Fragment> 
+                      <Table
+                        title={title}
+                        columns={columns}
+                        rows={history}
+                      />
+                      <div className={classes.citation}>
+                        <Typography variant="caption">
+                          Nutritional information provided by:
+                        </Typography>
+                        <Typography variant="caption">
+                          US Department of Agriculture, Agricultural Research Service,
+                          Nutrient Data Laboratory. USDA National Nutrient Database for
+                          Standard Reference, Release 28. Version Current: September
+                          2015. Internet:{' '}
+                          <a href="http://www.ars.usda.gov/ba/bhnrc/ndl">
+                            http://www.ars.usda.gov/ba/bhnrc/ndl
+                          </a>
+                        </Typography>
+                      </div>
+                    </React.Fragment>
+                  )
+                }}
+                </Query> 
+              </React.Fragment> 
+            )
+          }}
+          </Query>
+        </Paper>
+      </div>
+    )
+  }
+}
+
+export default withStyles(styles)(Temporal)

--- a/packages/titus-kitchen-sink/src/components/temporal/queries.graphql
+++ b/packages/titus-kitchen-sink/src/components/temporal/queries.graphql
@@ -1,0 +1,22 @@
+query loadFoodHistoryData($id: ID!) {
+  foodGroups: allFoodGroups {
+    id
+    name
+  }
+
+  foodHistory(id: $id) {
+    # we explicitly don't return the id to avoid apollo caching by id
+    # because id is the same or all histories of a food
+    name,
+    created,
+    modified,
+    sysPeriod {
+      begin,
+      end
+    },
+    foodGroup {
+      id
+      name
+    }
+  }
+}

--- a/packages/titus-kitchen-sink/src/menu.js
+++ b/packages/titus-kitchen-sink/src/menu.js
@@ -11,6 +11,7 @@ import InsertChart from '@material-ui/icons/InsertChart'
 import TablesIcon from '@material-ui/icons/GridOn'
 import AutocompleteIcon from '@material-ui/icons/Input'
 import ApiIcon from '@material-ui/icons/CloudQueue'
+import TemporalIcon from '@material-ui/icons/Timeline'
 import SearchIcon from '@material-ui/icons/FindInPage'
 import CommentIcon from '@material-ui/icons/Comment'
 import CloudUploadIcon from '@material-ui/icons/CloudUpload'
@@ -64,6 +65,12 @@ const Menu = () => {
           <ApiIcon />
         </ListItemIcon>
         <ListItemText primary="API" />
+      </ListItemLink>
+      <ListItemLink to={'/temporal'} getProps={isActiveRoute}>
+        <ListItemIcon>
+          <TemporalIcon />
+        </ListItemIcon>
+        <ListItemText primary="Temporal" />
       </ListItemLink>
       <ListItemLink to={'/search'} getProps={isActiveRoute}>
         <ListItemIcon>

--- a/packages/titus-kitchen-sink/src/routes.js
+++ b/packages/titus-kitchen-sink/src/routes.js
@@ -41,6 +41,12 @@ const AsyncApi = Loadable({
   delay: 300,
   timeout: 10000
 })
+const AsyncTemporal = Loadable({
+  loader: () => import('./components/temporal'),
+  loading: Loading,
+  delay: 300,
+  timeout: 10000
+})
 const AsyncSearch = Loadable({
   loader: () => import('./components/search/search'),
   loading: Loading,
@@ -74,6 +80,7 @@ const Routes = () => (
     <AsyncTables path="tables/*" />
     <AsyncAutocompleteDemo path="autocomplete/*" />
     <AsyncApi path="api/*" />
+    <AsyncTemporal path="temporal/*" />
     <AsyncSearch path="search/*" />
     <AsyncComments path="comments/*" />
     <AsyncUploader path="uploader/*" />


### PR DESCRIPTION
This implements temporal tables using [NearForm's custom extension](https://github.com/nearform/temporal_tables) (note the capital N!).

In the left drawer there is a new link (a timeline icon), which opens a new page containing a table which shows the history of a food record over time.

To see records in this table, make changes to a food in the /api demo section