### PR TITLE
fix translation API

### DIFF
--- a/packages/titus-fastify-backend/lib/routes/translations.js
+++ b/packages/titus-fastify-backend/lib/routes/translations.js
@@ -38,12 +38,13 @@ function plugin (server, opts, next) {
     },
     handler: async (request, reply) => {
       const { language, namespace } = request.params
+      const ns = namespace.split('.')[0] // Because we can't use ext in the route
 
-      if (!resources[language] || !resources[language][namespace]) {
+      if (!resources[language] || !resources[language][ns]) {
         return new httpErrors.NotFound()
       }
 
-      return resources[language][namespace]
+      return resources[language][ns]
     }
   })
 


### PR DESCRIPTION
Frontend i18next makes request to this URL with a `.json` as suffix. I can't seem to find a way to make it not do that. So tweaked the API to ignore the `.json` part and serve translation content based on namespace anyway.