### PR TITLE
batching dataloaders using preHandler hook

### DIFF
--- a/packages/titus-fastify-backend/lib/graphql/resolver/food.js
+++ b/packages/titus-fastify-backend/lib/graphql/resolver/food.js
@@ -17,7 +17,7 @@ const resolvers = {
   },
   Food: {
     foodGroup (root, args, context) {
-      return context.app.dataloaders(context.reply.request.dbClient).foodGroup.getByIds.load(root.foodGroupId)
+      return context.reply.request.dataloaders.foodGroup.getByIds.load(root.foodGroupId)
     }
   },
   Mutation: {

--- a/packages/titus-fastify-backend/lib/graphql/resolver/foodHistory.js
+++ b/packages/titus-fastify-backend/lib/graphql/resolver/foodHistory.js
@@ -8,7 +8,7 @@ const resolvers = {
   },
   FoodHistory: {
     foodGroup (root, args, context) {
-      return context.app.dataloaders(context.reply.request.dbClient).foodGroup.getByIds.load(root.foodGroupId)
+      return context.reply.request.dataloaders.foodGroup.getByIds.load(root.foodGroupId)
     }
   }
 }

--- a/packages/titus-fastify-backend/lib/plugins/dataloaders.js
+++ b/packages/titus-fastify-backend/lib/plugins/dataloaders.js
@@ -1,0 +1,16 @@
+const fastifyPlugin = require('fastify-plugin')
+const dataloaders = require('../dataloaders')
+
+function plugin (server, options, next) {
+  server.addHook('preHandler', async (request, reply) => {
+    request.dataloaders = dataloaders(request.dbClient)
+  })
+
+  next()
+}
+
+module.exports = fastifyPlugin(plugin, {
+  fastify: '1.x',
+  name: 'dataloaders-plugin',
+  dependencies: ['db-client-plugin']
+})

--- a/packages/titus-fastify-backend/lib/server.js
+++ b/packages/titus-fastify-backend/lib/server.js
@@ -9,6 +9,7 @@ const cors = require('fastify-cors')
 const config = require('../config/default')
 const graphql = require('./graphql')
 const dbClient = require('./plugins/db-client')
+const dataloaders = require('./plugins/dataloaders')
 
 const foodRoutes = require('./routes/rest/food')
 const foodGroupRoutes = require('./routes/rest/foodGroup')
@@ -40,6 +41,7 @@ const init = async () => {
         graphiql: true
       })
       .register(dbClient)
+      .register(dataloaders, {prefix: '/graphql'})
 
     // Register routes
     server
@@ -47,8 +49,6 @@ const init = async () => {
       .register(foodGroupRoutes)
       .register(dietTypeRoutes)
       .register(i18nRoutes)
-
-    server.decorate('dataloaders', graphql.dataloaders)
 
     await server.ready()
 


### PR DESCRIPTION
This way, there is a `dataloaders` request-wide, with a single `new`, and queries are using `getByIds` with multiple `ids` this time.

It could probably be improved by using some getter in order not to create a dataloader object if not needed, but it should be good enough like that