### PR TITLE
chore: fix link in readme

### DIFF
--- a/docs/developers/packages/README.md
+++ b/docs/developers/packages/README.md
@@ -9,7 +9,7 @@ Titus comes with two shell applications to get you started.
 ### titus-frontend
 The frontend, [titus-frontend](), is built on [create-react-app](), with the addition of [Storybook](), [Material UI](), [Reach Router]() and more. It includes demos of open source client libraries we use, NearForm's own open source projects and design system. It also shows how to use the React components contained in the [titus-components]() package.
 
-- [More information](packages/titus-frontend/README.md)
+- [More information](titus-frontend/)
 
 ### titus-backend
 The [backend](/kitchen-sink-backend) is built on [Hapi](), [PostgreSQL](), and [Docker](). It also includes demos of open source backend libraries and NearForm's open source packages.


### PR DESCRIPTION
Fix for issue: https://github.com/nearform/titus/issues/338