### PR TITLE
Fix/quickstart

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -108,7 +108,7 @@ To lint and test across the stack, use the command format `npm run <command>` in
 
 Both frontend and backend starter packages have linting and testing built in and run green in both cases by default. If any changes break the included rules, the starter package runs red.
 
-## Next Step
+## Next Steps
 If you would like more information, select the documentation most relevant to you:
 
 - Deep dive into our documentation for [Developers].


### PR DESCRIPTION
Fixes to quick start readme

- Move docker-compose sentence to relevant section
- Remove 'Manipulate the Running Stack' section is it is stale and replaced by the 'Manage the Database' section in the Developer docs - which is linked higher up the page.
- Remove the 'Stop the Stack' as the commands no longer exist
- Change 'Next Step' to 'Next Steps'