### PR TITLE
fix(storybook): fix storybook warning about CRA addon/preset

### DIFF
--- a/packages/titus-frontend/.storybook/main.js
+++ b/packages/titus-frontend/.storybook/main.js
@@ -2,11 +2,17 @@ module.exports = {
   stories: ['../src/**/*.story.(js|mdx)'],
   addons: [
     '@storybook/addon-a11y/register',
-    '@storybook/addon-docs',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        configureJSX: true
+      }
+    },
     '@storybook/addon-actions/register',
     '@storybook/addon-links/register',
     '@storybook/addon-knobs/register',
     '@storybook/addon-options/register',
+    '@storybook/preset-create-react-app',
     'storybook-readme/register'
   ]
 }

--- a/packages/titus-frontend/package-lock.json
+++ b/packages/titus-frontend/package-lock.json
@@ -4611,6 +4611,58 @@
         "core-js": "^3.0.1"
       }
     },
+    "@storybook/preset-create-react-app": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-create-react-app/-/preset-create-react-app-3.1.2.tgz",
+      "integrity": "sha512-MjOus6mH/F/TikTPR3lWiuaR6hhhray2Yr2jV++Qg1/fS3yyADTyNZQZyc+TOc+SdKNTZ706H8+zn7RcjD9vGg==",
+      "dev": true,
+      "requires": {
+        "@storybook/node-logger": "*",
+        "@types/babel__core": "^7.1.7",
+        "@types/webpack": "^4.41.13",
+        "babel-plugin-react-docgen": "^4.1.0",
+        "pnp-webpack-plugin": "^1.6.4",
+        "react-docgen-typescript-plugin": "^0.4.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@types/webpack": {
+          "version": "4.41.18",
+          "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.18.tgz",
+          "integrity": "sha512-mQm2R8vV2BZE/qIDVYqmBVLfX73a8muwjs74SpjEyJWJxeXBbsI9L65Pcia9XfYLYWzD1c1V8m+L0p30y2N7MA==",
+          "dev": true,
+          "requires": {
+            "@types/anymatch": "*",
+            "@types/node": "*",
+            "@types/tapable": "*",
+            "@types/uglify-js": "*",
+            "@types/webpack-sources": "*",
+            "source-map": "^0.6.0"
+          }
+        },
+        "pnp-webpack-plugin": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+          "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+          "dev": true,
+          "requires": {
+            "ts-pnp": "^1.1.6"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/react": {
       "version": "5.3.18",
       "resolved": "https://registry.npmjs.org/@storybook/react/-/react-5.3.18.tgz",
@@ -5616,6 +5668,78 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webpack-contrib/schema-utils": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
+      "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chalk": "^2.3.2",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "webpack-log": "^1.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "webpack-log": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+          "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.1.0",
+            "log-symbols": "^2.1.0",
+            "loglevelnext": "^1.0.1",
+            "uuid": "^3.1.0"
+          }
+        }
       }
     },
     "@wordpress/jest-puppeteer-axe": {
@@ -9795,6 +9919,17 @@
         "once": "^1.4.0"
       }
     },
+    "endent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/endent/-/endent-2.0.1.tgz",
+      "integrity": "sha512-mADztvcC+vCk4XEZaCz6xIPO2NHQuprv5CAEjuVAu6aZwqAj7nVNlMyl1goPFYqCCpS2OJV9jwpumJLkotZrNw==",
+      "dev": true,
+      "requires": {
+        "dedent": "^0.7.0",
+        "fast-json-parse": "^1.0.3",
+        "objectorarray": "^1.0.4"
+      }
+    },
     "enhanced-resolve": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
@@ -11075,6 +11210,12 @@
           }
         }
       }
+    },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -16758,6 +16899,16 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
       "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
     },
+    "loglevelnext": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "dev": true,
+      "requires": {
+        "es6-symbol": "^3.1.1",
+        "object.assign": "^4.1.0"
+      }
+    },
     "lolex": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
@@ -17864,6 +18015,12 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
+    },
+    "objectorarray": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.4.tgz",
+      "integrity": "sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==",
+      "dev": true
     },
     "obuf": {
       "version": "1.1.2",
@@ -20647,6 +20804,45 @@
         "neo-async": "^2.6.1",
         "node-dir": "^0.1.10",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "react-docgen-typescript": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.18.0.tgz",
+      "integrity": "sha512-nY4bXz44tLzXBVF+cyaL/gZsMxlmYVICaEIXFF4EqvD8PEN1+zL+IgaQ1mNfJ6Zq8jUFAeXDo1Ds7ylxWZtjXQ==",
+      "dev": true
+    },
+    "react-docgen-typescript-loader": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.7.2.tgz",
+      "integrity": "sha512-fNzUayyUGzSyoOl7E89VaPKJk9dpvdSgyXg81cUkwy0u+NBvkzQG3FC5WBIlXda0k/iaxS+PWi+OC+tUiGxzPA==",
+      "dev": true,
+      "requires": {
+        "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
+        "loader-utils": "^1.2.3",
+        "react-docgen-typescript": "^1.15.0"
+      }
+    },
+    "react-docgen-typescript-plugin": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.4.1.tgz",
+      "integrity": "sha512-+uoMqPWqPnC4+3xIz3e+AIJeJ07HZ1Y4jqziQ+xaRoxp9/RRR6XZK1hM5BRZmaMO2gN65I/jaFcxgaa/uzAtfQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "endent": "^2.0.1",
+        "micromatch": "^4.0.2",
+        "react-docgen-typescript": "^1.16.6",
+        "react-docgen-typescript-loader": "^3.7.2",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
       }
     },
     "react-dom": {

--- a/packages/titus-frontend/package.json
+++ b/packages/titus-frontend/package.json
@@ -52,6 +52,7 @@
     "@storybook/addon-storyshots": "^5.3.18",
     "@storybook/addon-storyshots-puppeteer": "^5.3.18",
     "@storybook/addons": "^5.3.18",
+    "@storybook/preset-create-react-app": "^3.1.2",
     "@storybook/react": "^5.3.18",
     "@testing-library/react": "^10.0.4",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
This PR fixes a console warning when running storybook/tests about the create react app preset being removed from Storybook's core in version 6.