### PR TITLE
feat(react): add error boundary to catch chunk loading errors

### DIFF
--- a/packages/titus-frontend/src/components/error-boundary/index.js
+++ b/packages/titus-frontend/src/components/error-boundary/index.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import { withTranslation } from 'react-i18next'
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>{this.props.t('errors.loadingFailed')}</p>
+    }
+
+    return this.props.children
+  }
+}
+
+export default withTranslation()(ErrorBoundary)

--- a/packages/titus-frontend/src/locale/en.json
+++ b/packages/titus-frontend/src/locale/en.json
@@ -29,6 +29,7 @@
     }
   },
   "errors": {
-    "tempPassword": "Please enter your temporary password and a new password"
+    "tempPassword": "Please enter your temporary password and a new password",
+    "loadingFailed": "Loading failed. Please reload"
   }
 }

--- a/packages/titus-frontend/src/locale/pt.json
+++ b/packages/titus-frontend/src/locale/pt.json
@@ -29,6 +29,7 @@
     }
   },
   "errors": {
-    "tempPassword": "Por favor indique a sua senha temporaria e uma senha nova."
+    "tempPassword": "Por favor indique a sua senha temporaria e uma senha nova.",
+    "loadingFailed": "Falha no carregamento. Por favor recarregue"
   }
 }

--- a/packages/titus-frontend/src/locale/ro.json
+++ b/packages/titus-frontend/src/locale/ro.json
@@ -29,6 +29,7 @@
     }
   },
   "errors": {
-    "tempPassword": "Te rugam sa introduci parola ta temporara si o noua parola"
+    "tempPassword": "Te rugam sa introduci parola ta temporara si o noua parola",
+    "loadingFailed": "Încărcarea a eșuat. Vă rugăm să reîncărcați"
   }
 }

--- a/packages/titus-frontend/src/router.js
+++ b/packages/titus-frontend/src/router.js
@@ -4,6 +4,7 @@ import { Route, Router, Redirect, Switch } from 'react-router-dom'
 import history from './history'
 import Layout from './components/layout'
 import Loading from './components/loading'
+import ErrorBoundary from './components/error-boundary'
 import { AuthContext } from './components/authentication/authentication-context'
 import { ROUTES } from './constants'
 
@@ -37,17 +38,22 @@ PrivateRoute.propTypes = {
 const AppRouter = () => {
   return (
     <Layout>
-      <Suspense fallback={<Loading />}>
-        <Router history={history}>
-          <Switch>
-            <Route path={ROUTES.LOGIN}>
-              <AsyncLogin />
-            </Route>
-            {/* INSERT NEW ROUTES HERE */}
-            <PrivateRoute path={ROUTES.DASHBOARD} component={AsyncDashboard} />
-          </Switch>
-        </Router>
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <Router history={history}>
+            <Switch>
+              <Route path={ROUTES.LOGIN}>
+                <AsyncLogin />
+              </Route>
+              {/* INSERT NEW ROUTES HERE */}
+              <PrivateRoute
+                path={ROUTES.DASHBOARD}
+                component={AsyncDashboard}
+              />
+            </Switch>
+          </Router>
+        </Suspense>
+      </ErrorBoundary>
     </Layout>
   )
 }


### PR DESCRIPTION
This PR adds an error boundary to catch chunk loading errors as suggested at https://web.dev/code-splitting-suspense/.

This can be tested by;

* opening the app in a logged out state
* turning off your internet connection
* entering a username & password and tapping 'LOGIN'

Notice that the error message is displayed.

This replaces the blank screen currently shown due to the chunk loading error.