### PR TITLE
Do not fetch remote aws config if remoteAwsConfigPath not set

### DIFF
--- a/packages/titus-frontend/src/components/remote-aws-config/index.js
+++ b/packages/titus-frontend/src/components/remote-aws-config/index.js
@@ -3,8 +3,16 @@ import React, { useState, useEffect } from 'react'
 import Loading from '../loading'
 import config from '../../config'
 
+const RemoteAwsConfigContainer = ({ children }) => {
+  if (!config.remoteAwsConfigPath) {
+    return <>{children}</>
+  }
+
+  return <RemoteAwsConfig>{children}</RemoteAwsConfig>
+}
+
 const RemoteAwsConfig = ({ children }) => {
-  const [isInit, setIsInit] = useState(!config.remoteAwsConfigPath)
+  const [isInit, setIsInit] = useState(false)
   const [error, setError] = useState()
   useEffect(() => {
     async function fetchConfig() {
@@ -45,4 +53,4 @@ const RemoteAwsConfig = ({ children }) => {
   return !isInit ? <Loading /> : <>{children}</>
 }
 
-export default RemoteAwsConfig
+export default RemoteAwsConfigContainer


### PR DESCRIPTION
if `remoteAwsConfigPath` is not set we currently set `isInit` to true to render `children` immediately, but the effect is still run, making a request to http://localhost:3000/undefined resulting in an error (that is also displayed on screen.

This PR introduce a `RemoteAwsConfigContainer` that bypasses `RemoteAwsConfig` entirely if `remoteAwsConfigPath` is not set.