### PR TITLE
Github Actions fixes

### DIFF
--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - 'packages/titus-backend/**'
-      - '.github/workflows/deploy_titus_backend.yml'
+      - '.github/workflows/backend-cd-gcp.yml'
 
 jobs:
   deploy-titus-backend:
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -31,14 +33,14 @@ jobs:
       - name: Set up GCP CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: '275.0.0'
+          version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Configure Docker repository
         run: |
-          echo "::set-env name=DOCKER_IMAGE::gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA"
+          echo "DOCKER_IMAGE=gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA" >> $GITHUB_ENV
           gcloud auth configure-docker
 
       - name: Build container

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checking out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/db-manager-cd-gcp.yml
+++ b/.github/workflows/db-manager-cd-gcp.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - 'packages/titus-db-manager/**'
-      - '.github/workflows/deploy_titus_db_manager.yml'
+      - '.github/workflows/db-manager-cd-gcp.yml'
 
 jobs:
   deploy-titus-db-manager:
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -31,14 +33,14 @@ jobs:
       - name: Set up GCP CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: '275.0.0'
+          version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Configure Docker repository
         run: |
-          echo "::set-env name=DOCKER_IMAGE::gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA"
+          echo "DOCKER_IMAGE=gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA" >> $GITHUB_ENV
           gcloud auth configure-docker
 
       - name: Build container

--- a/.github/workflows/db-manager-ci.yml
+++ b/.github/workflows/db-manager-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checking out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/frontend-cd-gcp.yml
+++ b/.github/workflows/frontend-cd-gcp.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - 'packages/titus-frontend/**'
-      - '.github/workflows/deploy_titus_frontend.yml'
+      - '.github/workflows/frontend-cd-gcp.yml'
       
 jobs:
   deploy-titus-frontend:
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -31,14 +33,14 @@ jobs:
       - name: Set up GCP CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: '275.0.0'
+          version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Configure Docker repository
         run: |
-          echo "::set-env name=DOCKER_IMAGE::gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA"
+          echo "DOCKER_IMAGE=gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA" >> $GITHUB_ENV
           gcloud auth configure-docker
 
       - name: Build container

--- a/.github/workflows/storybook-cd-gcp.yml
+++ b/.github/workflows/storybook-cd-gcp.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - 'packages/titus-frontend/**'
-      - '.github/workflows/deploy_titus_storybook.yml'
+      - '.github/workflows/storybook-cd-gcp.yml'
 
 jobs:
   deploy-titus-frontend:
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -31,14 +33,14 @@ jobs:
       - name: Set up GCP CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: '281.0.0'
+          version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Configure Docker repository
         run: |
-          echo "::set-env name=DOCKER_IMAGE::gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA"
+          echo "DOCKER_IMAGE=gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA" >> $GITHUB_ENV
           gcloud auth configure-docker
 
       - name: Build container


### PR DESCRIPTION
## Changes
- fixed GHA workflow file names in its triggers
- use `v2` version of `actions/checkout` GHA step with `fetch-depth: 1`
- use latest version of `GoogleCloudPlatform/github-actions/setup-gcloud`
- fixed GHA `set-env` env vars setup - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/