### PR TITLE
Backend GCP Service Account with perms to read DB password secret

### DIFF
--- a/infra/gcp/terraform/backend.tf
+++ b/infra/gcp/terraform/backend.tf
@@ -1,3 +1,14 @@
+resource "google_service_account" "backend" {
+  account_id   = "backend"
+  display_name = "backend"
+}
+
+resource "google_secret_manager_secret_iam_member" "backend_db_pass" {
+  secret_id = google_secret_manager_secret.db_password.secret_id
+  role = "roles/secretmanager.secretAccessor"
+  member = "serviceAccount:${google_service_account.backend.email}"
+}
+
 resource "google_cloud_run_service_iam_member" "backend_noauth" {
   location = google_cloud_run_service.backend.location
   service  = google_cloud_run_service.backend.name
@@ -11,6 +22,7 @@ resource "google_cloud_run_service" "backend" {
 
   template {
     spec {
+      service_account_name = google_service_account.backend.email
       containers {
         image = "gcr.io/cloudrun/hello"
         ports {
@@ -77,7 +89,6 @@ resource "google_cloud_run_service" "backend" {
   lifecycle {
     ignore_changes = [
       template[0].spec[0].containers[0].image,
-      template[0].spec[0].service_account_name,
       template[0].metadata[0].annotations
     ]
   }


### PR DESCRIPTION
## Changes
- created a new custom GCP service account with permissions to read DB password secret from Secret Manager (only)