### PR TITLE
Remove of unnecessary git add stage task from lint-staged pre-commit hook

### DIFF
--- a/packages/titus-backend/package.json
+++ b/packages/titus-backend/package.json
@@ -63,8 +63,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }

--- a/packages/titus-db-manager/package.json
+++ b/packages/titus-db-manager/package.json
@@ -57,8 +57,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }

--- a/packages/titus-frontend/package.json
+++ b/packages/titus-frontend/package.json
@@ -78,8 +78,7 @@
   "lint-staged": {
     "*.{js,css,md}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "jest": {


### PR DESCRIPTION
from v10 lint-staged does not need to use `git stage` task anymore

https://github.com/okonet/lint-staged#v10