### PR TITLE
chore: run ci on branches

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,15 +1,19 @@
 name: Backend CI
 on:
+  push:
+    paths:
+      - '.github/workflows/backend-ci.yml'
+      - 'packages/titus-backend/**'
   pull_request:
     paths:
-    - '.github/workflows/backend-ci.yml'
-    - 'packages/titus-backend/**'
+      - '.github/workflows/backend-ci.yml'
+      - 'packages/titus-backend/**'
 
 jobs:
   integration-checks:
     name: 'Linting, Testing'
     runs-on: ubuntu-latest
-    
+
     env:
       CI: true
 

--- a/.github/workflows/db-manager-ci.yml
+++ b/.github/workflows/db-manager-ci.yml
@@ -1,9 +1,13 @@
 name: DB Manager CI
 on:
+  push:
+    paths:
+      - '.github/workflows/db-manager-ci.yml'
+      - 'packages/titus-db-manager/**'
   pull_request:
     paths:
-    - '.github/workflows/db-manager-ci.yml'
-    - 'packages/titus-db-manager/**'
+      - '.github/workflows/db-manager-ci.yml'
+      - 'packages/titus-db-manager/**'
 
 jobs:
   integration-checks:
@@ -18,10 +22,10 @@ jobs:
           POSTGRES_PASSWORD: titus
           POSTGRES_DB: titus
         ports:
-        - 5432:5432
+          - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    
+
     env:
       CI: true
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,9 +1,13 @@
 name: Frontend CI
 on:
+  push:
+    paths:
+      - '.github/workflows/frontend-ci.yml'
+      - 'packages/titus-frontend/**'
   pull_request:
     paths:
-    - '.github/workflows/frontend-ci.yml'
-    - 'packages/titus-frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+      - 'packages/titus-frontend/**'
 
 jobs:
   integration-checks:

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,11 @@
   "labels": ["renovate"],
   "automerge": true,
   "automergeType": "branch",
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "updateTypes": ["major"],
+      "automergeType": "pr"
+    }
+  ]
 }


### PR DESCRIPTION
and configure renovate to automerge without creating PRs (therefore silently) except for major bumps