### PR TITLE
fix: avoid autoload on auth plugins in backend

### DIFF
--- a/packages/titus-backend/lib/plugins/auth/auth0/index.js
+++ b/packages/titus-backend/lib/plugins/auth/auth0/index.js
@@ -9,3 +9,4 @@ async function auth0(server, options) {
 }
 
 module.exports = fp(auth0)
+module.exports.autoload = false

--- a/packages/titus-backend/lib/plugins/auth/azure-ad/index.js
+++ b/packages/titus-backend/lib/plugins/auth/azure-ad/index.js
@@ -108,3 +108,4 @@ async function azureAD(server, options) {
 }
 
 module.exports = fp(azureAD)
+module.exports.autoload = false

--- a/packages/titus-backend/lib/plugins/auth/cognito/index.js
+++ b/packages/titus-backend/lib/plugins/auth/cognito/index.js
@@ -43,3 +43,4 @@ async function cognito(server, options) {
 }
 
 module.exports = fp(cognito)
+module.exports.autoload = false

--- a/packages/titus-backend/lib/plugins/auth/index.js
+++ b/packages/titus-backend/lib/plugins/auth/index.js
@@ -9,7 +9,7 @@ const authProviders = {
 }
 
 async function auth(server, options) {
-  server.register(authProviders[options.auth.provider || 'auth0'], options)
+  server.register(authProviders[options.auth.provider], options)
 }
 
 module.exports = fp(auth)


### PR DESCRIPTION
because the index.js file conditionally registers them. Looks like something has changed in the behavior of fastify-autoload which recursively registers plugins in the plugins folder, whereas we don't want that for the authorization plugins, since its index.js entrypoint conditionally registers the auth plugin based on configuration.

This wasn't caught by automated tests possibly because no tests execute the whole server.