### PR TITLE
fix(docs): added frontend build to quick-start

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -5,6 +5,7 @@ Titus is easy to install and run. We encourage developers to install Titus local
 You need the latest stable versions of [Node] and [Docker]. Both of these are straightforward to install and do not require any special setup. There are other tools to install for deployment purposes, these are described in the [DevOps] section of this documentation.
 
 ## Clone the Source Repository
+
 To start, fork [Titus] on GitHub. It is easier to maintain your own fork as Titus is designed to diverge. It is unlikely you will need to pull from the source repository again.
 
 Once you have your fork, clone a copy of it locally:
@@ -14,6 +15,7 @@ git clone https://github.com/<your-fork>/titus.git
 ```
 
 ## Install Dependencies
+
 Change directory to the root folder of the project, and run the following npm command:
 
 ```sh
@@ -23,6 +25,7 @@ npm install
 Dependencies are installed for all parts of the repository.
 
 ## Configure the Environment
+
 Titus uses the `.env` files in each package to control various configurations. There are `.sample.env` files for each package, documenting sample values that can be used in each `.env` file.
 
 Before running the stack, generate a default set of `.env` files for all packages. To do this, run the following command in the root directory of the project:
@@ -31,26 +34,28 @@ Before running the stack, generate a default set of `.env` files for all package
 npm run create:env
 ```
 
-You can read more about configuring the environment in the [Developers][DevelopersBe] section of our documentation.
+You can read more about configuring the environment in the [Developers][developersbe] section of our documentation.
 
 ## Bring up the Database
 
-You can run the database as a stand-alone container or as a HTTP server. 
+You can run the database as a stand-alone container or as a HTTP server.
 
 For more information on how to manage the database, refer to [Manage the Database] in the Developer section of this documentation.
 
 ### Run the Database as a Stand-alone Container
+
 To spin up the database run the command:
 
 ```sh
 npm run db:up
 ```
 
- You can check the `docker-compose.yml` file in the root of the repository for specifics of what is running in Docker.
+You can check the `docker-compose.yml` file in the root of the repository for specifics of what is running in Docker.
 
 ### Run the Database as a HTTP Server
 
 You can start a separate HTTP database server with the command:
+
 ```sh
 npm run db:server:start
 ```
@@ -71,6 +76,7 @@ server.register(titusDbManager)
 - `POST /db/migrate` runs the migrations
 
 ## Run the Stack
+
 Titus runs your application locally, leveraging Docker for external services such as a database.
 We take advantage of Lerna shortcuts to start all the packages in sequence.
 Our packages support hot reloading, using [webpack devServer][webpack-dev-server] (for Titus frontend) and [NodeMon] (for Titus backend).
@@ -87,6 +93,7 @@ Frontend and backend logs are output to the console if you run the stack with th
 Congratulations! You are now running Titus locally.
 
 ### Log In
+
 The application is accessed at `localhost:3000` in a web browser. First access requires you to log in to the system:
 
 ![x](../img/titus-login.png)
@@ -102,13 +109,21 @@ The home page links you to the documentation (here), if you did not start from t
 **Note:** You can log out of the system from the home page.
 
 ### Lint and Test
+
+For new installs, you will need to build the frontend before `test:all`.
+
+- `cd packages/titus-frontend npm run build`
+- ` cd ../..`
+
 To lint and test across the stack, use the command format `npm run <command>` in the root directory of the repository. For example:
+
 - `npm run lint:all`- Runs the `lint` command in each package that has one
 - `npm run test:all`- Runs the `test` command in each package that has one
 
 Both frontend and backend starter packages have linting and testing built in and run green in both cases by default. If any changes break the included rules, the starter package runs red.
 
 ## Next Steps
+
 If you would like more information, select the documentation most relevant to you:
 
 - Deep dive into our documentation for [Developers].
@@ -116,15 +131,17 @@ If you would like more information, select the documentation most relevant to yo
 - [Frontend Quick Start](developers/packages/titus-frontend/?id=quick-start).
 
 <!-- External Links -->
-[Docker]: https://docs.docker.com/install/#supported-platforms
-[Node]: https://nodejs.org/en/
+
+[docker]: https://docs.docker.com/install/#supported-platforms
+[node]: https://nodejs.org/en/
 [npm]: https://www.npmjs.com/get-npm
-[Titus]: https://github.com/nearform/titus
+[titus]: https://github.com/nearform/titus
 [webpack-dev-server]: https://webpack.js.org/configuration/dev-server
-[Nodemon]: https://nodemon.io
+[nodemon]: https://nodemon.io
 
 <!-- Internal Links -->
-[DevOps]: devops/
-[Developers]: developers/
-[Manage the Database]: developers/packages/titus-db-manager/?id=manage-the-database
-[DevelopersBe]: developers/?id=backend-package
+
+[devops]: devops/
+[developers]: developers/
+[manage the database]: developers/packages/titus-db-manager/?id=manage-the-database
+[developersbe]: developers/?id=backend-package


### PR DESCRIPTION
Added the build criteria for fresh installs in the quick start docs.

Without that, the `mira` tests will fail.