### PR TITLE
Create an alias for storybook

### DIFF
--- a/packages/titus-frontend/.storybook/main.js
+++ b/packages/titus-frontend/.storybook/main.js
@@ -1,3 +1,4 @@
+const path = require('path')
 module.exports = {
   stories: ['../src/**/*.story.@(js|mdx)'],
   addons: [
@@ -13,5 +14,12 @@ module.exports = {
     '@storybook/addon-knobs/register',
     '@storybook/preset-create-react-app',
     'storybook-readme/register'
-  ]
+  ],
+  webpackFinal: async config => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '.storybook': path.resolve(__dirname)
+    }
+    return config
+  }
 }


### PR DESCRIPTION
This fixes storybook file imports being broken due to https://github.com/nearform/titus/pull/644

Adds a custom webpack alias for `.storybook` so that storybook config files can be imported absolutely in stories.