### PR TITLE
chore(deps): use node 14 lts for mira

### DIFF
--- a/packages/titus-infra-aws-mira/pipeline/buildspec.sample.yaml
+++ b/packages/titus-infra-aws-mira/pipeline/buildspec.sample.yaml
@@ -10,7 +10,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 14
     commands:
       - npm install
       - npm run postinstall


### PR DESCRIPTION
closes https://github.com/nearform/titus/issues/635