### PR TITLE
Rewriting getting started commands for testing

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -110,10 +110,17 @@ The home page links you to the documentation (here), if you did not start from t
 
 ### Lint and Test
 
-For new installs, you will need to build the frontend before `test:all`.
+---
+**NOTE**
 
-- `cd packages/titus-frontend npm run build`
-- ` cd ../..`
+For new installs, you will need to build the frontend before `test:all`. To build the project, run the command:
+
+
+```bash
+npm run build:all
+```
+---
+
 
 To lint and test across the stack, use the command format `npm run <command>` in the root directory of the repository. For example:
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "titus-lib",
     "scripts": {
         "test": "jest --config .jest.json --coverage"
     },


### PR DESCRIPTION
This PR intends to remark the importance of building the frontend before running the tests. 

Also it decorates the build commands for better readability .

It may be related to #636 