### PR TITLE
Prefer package.location to package.name in (create/clean)Env fns

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -25,7 +25,9 @@ function cleanEnv() {
   for (const pkgDir of pkgDirs) {
     const env = `${pkgDir}/.env`
 
-    if (!fs.existsSync(env)) continue
+    if (!fs.existsSync(env)) {
+      continue
+    }
 
     try {
       fs.unlinkSync(env)
@@ -40,7 +42,9 @@ function createEnv() {
   for (const pkgDir of pkgDirs) {
     const sample = `${pkgDir}/.env.sample`
 
-    if (!fs.existsSync(sample)) continue
+    if (!fs.existsSync(sample)) {
+      continue
+    }
 
     const env = `${pkgDir}/.env`
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -8,51 +8,49 @@ const chalk = require('chalk')
 const warning = chalk.keyword('yellow')
 const info = chalk.keyword('green')
 
-let packages
-
-try {
-  const output = execSync('npx lerna ls --all --json')
-  packages = JSON.parse(output.toString()).map(
-    packageItem => `../packages/${packageItem.name}`
-  )
-} catch (error) {
-  console.log(warning('No packages found'))
-  process.exit(0)
+const pkgDirs = getPkgDirs()
+function getPkgDirs() {
+  try {
+    const packages = execSync('npx lerna ls --all --json')
+    return JSON.parse(packages.toString()).map(
+      ({ location }) => location
+    )
+  } catch (error) {
+    console.log(warning('No packages found'))
+    process.exit(0)
+  }
 }
 
 function cleanEnv() {
-  for (const pathDir of packages) {
-    const env = path.resolve(__dirname, `${pathDir}/.env`)
+  for (const pkgDir of pkgDirs) {
+    const env = `${pkgDir}/.env`
 
-    if (!fs.existsSync(env)) {
-      continue
-    }
+    if (!fs.existsSync(env)) continue
 
     try {
       fs.unlinkSync(env)
-      console.log(info(`Removed env on ${pathDir}`))
+      console.log(info(`Removed .env file at ${pkgDir}`))
     } catch (err) {
-      console.log(warning(`No env file on ${pathDir}`))
+      console.log(warning(`No .env file at ${pkgDir}`))
     }
   }
 }
 
 function createEnv() {
-  for (const pathDir of packages) {
-    const sample = path.resolve(__dirname, `${pathDir}/.env.sample`)
-    const env = path.resolve(__dirname, `${pathDir}/.env`)
+  for (const pkgDir of pkgDirs) {
+    const sample = `${pkgDir}/.env.sample`
 
-    if (!fs.existsSync(sample)) {
-      continue
-    }
+    if (!fs.existsSync(sample)) continue
+
+    const env = `${pkgDir}/.env`
 
     try {
       fs.accessSync(env)
-      console.log(warning(`File on ${pathDir} already exist`))
+      console.log(warning(`.env file at ${pkgDir} already exists`))
     } catch (err) {
       if (err && err.code === 'ENOENT') {
         fs.copyFileSync(sample, env)
-        console.log(info(`Created env on ${pathDir}`))
+        console.log(info(`Created .env file at ${pkgDir}`))
       }
     }
   }


### PR DESCRIPTION
Closes #851 

With this PR, the `create:env` and `clean:env` scripts will use each package's `location` property to look for or create corresponding `.env` / `.env.sample` files. This change makes it possible to have a package name that does not exactly equal the name of the package's containing directory.

Other minor updates include:
1. Improve logging messages.
2. Simplify code since we now have a path, rather than a name that needs to be concatenated into a path.
3. Minor 'improvements' based on developer preference.

Test Results:
![image](https://user-images.githubusercontent.com/385695/117125208-86e9c180-ad99-11eb-941e-762af4fc95f4.png)
