### PR TITLE
docs: link AWS page in sidebar

### DIFF
--- a/docs/devops/_sidebar.md
+++ b/docs/devops/_sidebar.md
@@ -5,6 +5,6 @@
     - [Overview](/devops/?id=overview)
     - [Deploy Titus](/devops/?id=deploy-titus)
         - [Deploy on GCP](/devops/gcp/)
-        - [Deploy on AWS with Mira](https://github.com/nearform/titus/tree/master/packages/titus-infra-aws-mira)
-        - [Deploy Titus on Azure](/devops/azure/?id=Deploy-Titus-on-Azure)
+        - [Deploy on AWS](/devops/aws/)
+        - [Deploy on Azure](/devops/azure/?id=Deploy-Titus-on-Azure)
 - [Contribute to Titus](/contributing/)

--- a/docs/devops/aws/README.md
+++ b/docs/devops/aws/README.md
@@ -1,4 +1,4 @@
-# Titus Aws Cdk Deploy with Terraform
+# Titus AWS Deploy with Terraform
 
 This package allows to deploy easily the titus project on a AWS account.
 


### PR DESCRIPTION
The new documentation to deploy on AWS using terraform was not linked into the sidebar.