### PR TITLE
updates code and docs to support terraform 1.0.0

### DIFF
--- a/docs/devops/gcp/README.md
+++ b/docs/devops/gcp/README.md
@@ -2,7 +2,7 @@
 
 To set up a [Titus] deployment on an [GCP] cloud using [Github Actions], there are few steps to be performed.
 
-**Note:** [Terraform] 0.14 is required for the infrastructure creation.
+**Note:** This code supports [Terraform] 1.0.0 and above.
 
 ## Infrastructure Stack
 

--- a/infra/gcp/terraform/main.tf
+++ b/infra/gcp/terraform/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.0.0"
   backend "gcs" {
     credentials = "key.json"
     bucket      = "titus-terraform-state"


### PR DESCRIPTION
The code was already compatible with terraform 1.0.0, this PR just updates the documentation and sets a `required_version` statement as in the other `main.tf` files (for AWS and Azure)

Closes #933 