### PR TITLE
Updates SECRETS_PG_PASS env value

### DIFF
--- a/infra/azure/terraform/backend.tf
+++ b/infra/azure/terraform/backend.tf
@@ -33,7 +33,6 @@ resource "azurerm_container_group" "titus-backend-containergroup" {
       "PG_PORT"     = "5432"
       "PG_DB"       = azurerm_postgresql_database.titus-db.name
       "PG_USER"     = "${var.db_user}@${azurerm_postgresql_server.titus-db-server.name}"
-      "PG_PASS"     = azurerm_key_vault_secret.titus-db-password.value
       "SECRETS_STRATEGY" = "azure"
       "SECRETS_PG_PASS" = format("%s|%s", azurerm_key_vault.titus-key-vault.id, azurerm_key_vault_secret.titus-db-password.value)
       "JWT_SECRET"  = azurerm_key_vault_secret.titus-jwt-secret.value

--- a/infra/azure/terraform/backend.tf
+++ b/infra/azure/terraform/backend.tf
@@ -34,8 +34,8 @@ resource "azurerm_container_group" "titus-backend-containergroup" {
       "PG_DB"       = azurerm_postgresql_database.titus-db.name
       "PG_USER"     = "${var.db_user}@${azurerm_postgresql_server.titus-db-server.name}"
       "PG_PASS"     = azurerm_key_vault_secret.titus-db-password.value
-      #"SECRETS_STRATEGY" = "azure"
-      "SECRETS_PG_PASS" = "PG_PASS"
+      "SECRETS_STRATEGY" = "azure"
+      "SECRETS_PG_PASS" = format("%s|%s", azurerm_key_vault.titus-key-vault.id, azurerm_key_vault_secret.titus-db-password.value)
       "JWT_SECRET"  = azurerm_key_vault_secret.titus-jwt-secret.value
       "NODE_ENV"    = "development"
       "AUTH0_DOMAIN" = "dummy"

--- a/infra/azure/terraform/db-manager.tf
+++ b/infra/azure/terraform/db-manager.tf
@@ -33,8 +33,8 @@ resource "azurerm_container_group" "titus-db-manager-containergroup" {
       "PG_DATABASE" = azurerm_postgresql_database.titus-db.name
       "PG_USER"     = "${var.db_user}@${azurerm_postgresql_server.titus-db-server.name}"
       "PG_PASSWORD"     = azurerm_key_vault_secret.titus-db-password.value
-      "SECRETS_STRATEGY" = "env"
-      "SECRETS_PG_PASS" = "PG_PASSWORD"
+      "SECRETS_STRATEGY" = "azure"
+      "SECRETS_PG_PASS" = format("%s|%s", azurerm_key_vault.titus-key-vault.id, azurerm_key_vault_secret.titus-db-password.value)
       "JWT_SECRET"  = azurerm_key_vault_secret.titus-jwt-secret.value
       "NODE_ENV"    = "development"
       "AUTH0_DOMAIN" = "dummy"


### PR DESCRIPTION
Containerized apps in Azure now uses by default `azure` secrets strategy and the correct value for db password.

Closes #1004 