### PR TITLE
add: configurable pg schema

### DIFF
--- a/docs/developers/packages/titus-db-manager/README.md
+++ b/docs/developers/packages/titus-db-manager/README.md
@@ -69,7 +69,17 @@ Use the following commands with your Titus database:
 |`npm run db:seed` | Seed the database with dev data from `tools/migrations/seed_dev` with [postgrator].|
 |`npm run db:truncate` | Apply SQL truncate scripts with `psql` CLI against your database.|
 
+### Database `schema`
 
+Optionally, you can provide to the `db:migrate` two extra positional arguments:
+
+```bash
+npm run db:migrate [schema] [directory]
+# eg: npm run db:migrate titus-app /titus-app
+```
+
+- schema: the database's schema to migrate. Default is [`public`](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC).
+- migrations' directory: where the migration scripts are located. Default `/migrations`
 
 [Jest]: https://jestjs.io
 [ESLint]: https://eslint.org

--- a/packages/titus-db-manager/index.js
+++ b/packages/titus-db-manager/index.js
@@ -37,9 +37,18 @@ async function run() {
       password
     }
 
-    await start(process.argv[2] || 'migrate', credentials)
+    const action = process.argv[2] || 'migrate'
+    // default PG schema https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC
+    const schema = process.argv[3] || 'public'
+    const customDir = process.argv[4] || '/migrations'
+
+    await start(action, credentials, {
+      logger,
+      schema,
+      dir: customDir
+    })
   } catch (err) {
-    logger.error('An Error has occurred, stopping', err)
+    logger.error(err, 'An Error has occurred, stopping')
     process.exit(1)
   }
 }

--- a/packages/titus-db-manager/index.js
+++ b/packages/titus-db-manager/index.js
@@ -38,7 +38,6 @@ async function run() {
     }
 
     const action = process.argv[2] || 'migrate'
-    // default PG schema https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC
     const schema = process.argv[3] || 'public'
     const customDir = process.argv[4] || '/migrations'
 

--- a/packages/titus-db-manager/index.js
+++ b/packages/titus-db-manager/index.js
@@ -37,14 +37,16 @@ async function run() {
       password
     }
 
-    const action = process.argv[2] || 'migrate'
-    const schema = process.argv[3] || 'public'
-    const customDir = process.argv[4] || '/migrations'
+    const [
+      action = 'migrate',
+      schema = 'public',
+      migrationsLoadDir = '/migrations'
+    ] = process.argv.slice(2)
 
     await start(action, credentials, {
       logger,
       schema,
-      dir: customDir
+      dir: migrationsLoadDir
     })
   } catch (err) {
     logger.error(err, 'An Error has occurred, stopping')

--- a/packages/titus-db-manager/lib/routes.js
+++ b/packages/titus-db-manager/lib/routes.js
@@ -13,7 +13,7 @@ const Truncate = require('../truncate')
 const { version } = require('../package')
 
 const inputSchema = S.oneOf([
-  S.type('null'),
+  S.null(),
   S.object()
     .description('Optional schema to process')
     .prop('schema', S.string().minLength(1))

--- a/packages/titus-db-manager/lib/routes.js
+++ b/packages/titus-db-manager/lib/routes.js
@@ -57,7 +57,7 @@ async function dbRoutes(server) {
         await client.connect()
 
         const pg = new Postgrator(postgratorConfig)
-        const migrateResult = await Migrate(pg)
+        const migrateResult = await Migrate(pg, { logger: req.log })
         return { success: migrateResult }
       } catch (e) {
         req.log.error({ err: e })
@@ -91,7 +91,7 @@ async function dbRoutes(server) {
       })
       try {
         await client.connect()
-        await Truncate(client)
+        await Truncate(client, { logger: req.log })
         return { success: true }
       } catch (e) {
         req.log.error({ err: e })
@@ -125,7 +125,7 @@ async function dbRoutes(server) {
       })
       try {
         await client.connect()
-        await Seed(client)
+        await Seed(client, { logger: req.log })
         return { success: true }
       } catch (e) {
         req.log.error({ err: e })

--- a/packages/titus-db-manager/lib/routes.js
+++ b/packages/titus-db-manager/lib/routes.js
@@ -5,28 +5,19 @@ const path = require('path')
 const { Client } = require('pg')
 const Postgrator = require('postgrator')
 const fp = require('fastify-plugin')
+const S = require('fluent-schema')
 
 const Seed = require('../seed')
 const Migrate = require('../migrate')
 const Truncate = require('../truncate')
 const { version } = require('../package')
 
-const inputSchema = {
-  oneOf: [
-    { type: 'null' },
-    {
-      description: 'Optional schema to process',
-      type: 'object',
-      properties: {
-        schema: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 64
-        }
-      }
-    }
-  ]
-}
+const inputSchema = S.oneOf([
+  S.type('null'),
+  S.object()
+    .description('Optional schema to process')
+    .prop('schema', S.string().minLength(1))
+])
 
 const config = require('./config')
 async function dbRoutes(server) {

--- a/packages/titus-db-manager/lib/server.integration.test.js
+++ b/packages/titus-db-manager/lib/server.integration.test.js
@@ -67,7 +67,7 @@ describe('Server Integration', () => {
 
       expect(response.json()).toEqual({
         success: false,
-        message: 'relation "some_table" does not exist'
+        message: 'relation "public.some_table" does not exist'
       })
     })
 
@@ -84,6 +84,36 @@ describe('Server Integration', () => {
 
       expect(response.json()).toEqual({
         success: true
+      })
+    })
+  })
+
+  describe('custom postgres schema', () => {
+    it('migrate and truncated different schemas', async () => {
+      await fastify.inject({
+        method: 'POST',
+        url: '/db/migrate'
+      })
+
+      await fastify.inject({
+        method: 'POST',
+        url: '/db/migrate',
+        payload: {
+          schema: 'test-schema'
+        }
+      })
+
+      await fastify.inject({
+        method: 'POST',
+        url: '/db/truncate'
+      })
+
+      await fastify.inject({
+        method: 'POST',
+        url: '/db/truncate',
+        payload: {
+          schema: 'test-schema'
+        }
       })
     })
   })

--- a/packages/titus-db-manager/lib/server.test.js
+++ b/packages/titus-db-manager/lib/server.test.js
@@ -135,6 +135,7 @@ describe('Server', () => {
 
       expect(Postgrator).toHaveBeenCalledWith(
         expect.objectContaining({
+          currentSchema: 'public',
           database: 'titus',
           driver: 'pg',
           host: 'localhost',
@@ -143,7 +144,7 @@ describe('Server', () => {
           password: 'titus',
           poolSize: 10,
           port: 5432,
-          schemaTable: 'schema_migrations',
+          schemaTable: 'public.schema_migrations',
           user: 'titus',
           validateChecksums: true
         })
@@ -163,6 +164,7 @@ describe('Server', () => {
 
       expect(Postgrator).toHaveBeenCalledWith(
         expect.objectContaining({
+          currentSchema: 'public',
           database: 'titus',
           driver: 'pg',
           host: 'localhost',
@@ -171,7 +173,7 @@ describe('Server', () => {
           password: 'titus',
           poolSize: 10,
           port: 5432,
-          schemaTable: 'schema_migrations',
+          schemaTable: 'public.schema_migrations',
           user: 'titus',
           validateChecksums: true
         })

--- a/packages/titus-db-manager/migrate/index.js
+++ b/packages/titus-db-manager/migrate/index.js
@@ -1,11 +1,7 @@
 'use strict'
 
-const logger = require('pino')()
-
-const migrate = async pg => {
+module.exports = async function migrate(pg, { logger }) {
   await pg.migrate()
   logger.info('Database migrated')
   return true
 }
-
-module.exports = migrate

--- a/packages/titus-db-manager/migrate/index.test.js
+++ b/packages/titus-db-manager/migrate/index.test.js
@@ -5,7 +5,11 @@ describe('migrate', () => {
     const pg = {
       migrate: jest.fn().mockResolvedValueOnce(null)
     }
-    const result = await migrate(pg)
+    const result = await migrate(pg, {
+      logger: {
+        info: jest.fn()
+      }
+    })
     expect(result).toBe(true)
     expect(pg.migrate).toHaveBeenCalledTimes(1)
   })

--- a/packages/titus-db-manager/migration-start.js
+++ b/packages/titus-db-manager/migration-start.js
@@ -4,47 +4,51 @@ const path = require('path')
 
 const Postgrator = require('postgrator')
 const { Client } = require('pg')
-const logger = require('pino')()
 
-const Seed = require('./seed')
-const Migrate = require('./migrate')
-const Truncate = require('./truncate')
+const seed = require('./seed')
+const migrate = require('./migrate')
+const truncate = require('./truncate')
 
-const start = async (action, credentials) => {
+const start = async (action, credentials, opts = {}) => {
+  const { logger, schema, dir = schema } = opts
+
   logger.info(`Starting titus-db-manager tool`)
 
-  const valid =
-    action === 'migrate' || action === 'seed' || action === 'truncate'
-
-  if (!valid) {
-    logger.info(`${action} is not a valid action, stopping`)
+  if (!(action === 'migrate' || action === 'seed' || action === 'truncate')) {
+    logger.warn(`${action} is not a valid action, stopping`)
     return
   }
 
-  logger.info(`Running: ${action}`)
+  logger.info(`Running: ${action} on schema '${schema}'`)
   const client = new Client(credentials)
   await client.connect()
 
-  if (action === 'migrate') {
-    const pg = await new Postgrator({
-      validateChecksums: true,
-      newline: 'LF',
-      migrationPattern: path.join(__dirname, '/migrate/migrations/*.sql'),
-      driver: 'pg',
-      ...credentials,
-      schemaTable: `schema_migrations`,
-      execQuery: query => client.query(query)
-    })
-    await Migrate(pg)
-  } else {
-    if (action === 'seed') {
-      await Seed(client)
-    } else if (action === 'truncate') {
-      await Truncate(client)
+  switch (action) {
+    case 'migrate': {
+      const migrationPattern = path.join(__dirname, 'migrate', dir, '*.sql')
+      logger.info(`Running migrations matching ${migrationPattern}`)
+      const pg = await new Postgrator({
+        validateChecksums: true,
+        newline: 'LF',
+        migrationPattern,
+        driver: 'pg',
+        schemaTable: `${schema}.schema_migrations`,
+        currentSchema: schema,
+        execQuery: query => client.query(query)
+      })
+      await migrate(pg, opts)
+      break
     }
-
-    await client.end()
+    case 'seed': {
+      await seed(client, opts)
+      break
+    }
+    case 'truncate': {
+      await truncate(client, opts)
+    }
   }
+
+  await client.end()
 }
 
 module.exports = start

--- a/packages/titus-db-manager/seed/index.js
+++ b/packages/titus-db-manager/seed/index.js
@@ -1,5 +1,6 @@
-const seed = async pg => {
-  console.log('Database seeded')
-}
+'use strict'
 
-module.exports = seed
+module.exports = async function seed(pg, { logger }) {
+  logger.info('Database seeded')
+  return true
+}

--- a/packages/titus-db-manager/seed/index.test.js
+++ b/packages/titus-db-manager/seed/index.test.js
@@ -3,7 +3,11 @@ const seed = require('.')
 describe('seed', () => {
   it('runs seed command', async () => {
     const pg = {}
-    const result = await seed(pg)
-    expect(result).toBe(undefined)
+    const result = await seed(pg, {
+      logger: {
+        info: jest.fn()
+      }
+    })
+    expect(result).toBe(true)
   })
 })

--- a/packages/titus-db-manager/truncate/index.js
+++ b/packages/titus-db-manager/truncate/index.js
@@ -1,11 +1,11 @@
-const truncate = async pg => {
+'use strict'
+
+module.exports = async function truncate(pg, { logger }) {
   await pg.query(`
     TRUNCATE TABLE
       some_table
     RESTART IDENTITY;
   `)
-
-  console.log('Database truncated')
+  logger.info('Database truncated')
+  return true
 }
-
-module.exports = truncate

--- a/packages/titus-db-manager/truncate/index.js
+++ b/packages/titus-db-manager/truncate/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-module.exports = async function truncate(pg, { logger }) {
+module.exports = async function truncate(pg, { schema, logger }) {
   await pg.query(`
     TRUNCATE TABLE
-      some_table
+      ${schema}.some_table
     RESTART IDENTITY;
   `)
   logger.info('Database truncated')

--- a/packages/titus-db-manager/truncate/index.test.js
+++ b/packages/titus-db-manager/truncate/index.test.js
@@ -6,6 +6,7 @@ describe('truncate', () => {
       query: jest.fn().mockResolvedValueOnce(null)
     }
     const result = await truncate(pg, {
+      schema: 'foo',
       logger: {
         info: jest.fn()
       }
@@ -13,7 +14,7 @@ describe('truncate', () => {
     expect(result).toBe(true)
     expect(pg.query).toHaveBeenCalledWith(`
     TRUNCATE TABLE
-      some_table
+      foo.some_table
     RESTART IDENTITY;
   `)
   })

--- a/packages/titus-db-manager/truncate/index.test.js
+++ b/packages/titus-db-manager/truncate/index.test.js
@@ -5,8 +5,12 @@ describe('truncate', () => {
     const pg = {
       query: jest.fn().mockResolvedValueOnce(null)
     }
-    const result = await truncate(pg)
-    expect(result).toBe(undefined)
+    const result = await truncate(pg, {
+      logger: {
+        info: jest.fn()
+      }
+    })
+    expect(result).toBe(true)
     expect(pg.query).toHaveBeenCalledWith(`
     TRUNCATE TABLE
       some_table


### PR DESCRIPTION
implements #924 

TODOs:

- [x] add `schema` input to the API
- [x] document the new `schema` argument
- [x] document and test the new `dir` argument (it will not be added to the endpoint)