### PR TITLE
Fix/docker push

### DIFF
--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/docker-push
     paths:
       - 'packages/titus-backend/**'
       - '.github/workflows/backend-cd-gcp.yml'
@@ -27,7 +26,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -39,7 +39,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Configure Docker repository
+      - name: Configure Docker registry
         run: |
           gcloud components install beta
           gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
@@ -108,6 +108,7 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Delete Docker artifacts
+        if: always()
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.DOCKER_SAVE_ARTIFACT }}

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -82,12 +82,10 @@ jobs:
           path: /tmp
 
       - name: Load Docker image
-        run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
+        run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT | tee /tmp/docker-image.txt
 
       - name: Push Docker image
-        run: |
-          echo $DOCKER_IMAGE
-          docker push $DOCKER_IMAGE
+        run: docker push $(cat /tmp/docker-image.txt | cut -d " " -f 3)
 
       - name: Run service
         uses: google-github-actions/deploy-cloudrun@v0.7.0

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -11,17 +11,15 @@ on:
 
 env:
   DOCKER_SAVE_ARTIFACT: docker-save.tar
+  DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
+  CLOUDRUN_SERVICE_NAME: titus-backend
+  CLOUDRUN_SERVICE_REGION: europe-west1
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-backend:
     name: Build titus-backend
     runs-on: ubuntu-latest
-
-    env:
-      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
-      CLOUDRUN_SERVICE_NAME: titus-backend
-      CLOUDRUN_SERVICE_REGION: europe-west1
 
     steps:
       - name: Checkout project
@@ -45,7 +43,6 @@ jobs:
         run: |
           gcloud components install beta
           gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
-
           echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/backend:$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Build Docker image
@@ -75,6 +72,20 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Configure Docker registry
+        run: |
+          gcloud components install beta
+          gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
+          echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/backend:$GITHUB_SHA" >> $GITHUB_ENV
+
       - name: Download Docker image from artifacts store
         uses: actions/download-artifact@v2
         with:
@@ -82,10 +93,10 @@ jobs:
           path: /tmp
 
       - name: Load Docker image
-        run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT | tee /tmp/docker-image.txt
+        run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
 
       - name: Push Docker image
-        run: docker push $(cat /tmp/docker-image.txt | cut -d " " -f 3)
+        run: docker push $DOCKER_IMAGE
 
       - name: Run service
         uses: google-github-actions/deploy-cloudrun@v0.7.0

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/docker-push
     paths:
       - 'packages/titus-backend/**'
       - '.github/workflows/backend-cd-gcp.yml'

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -83,9 +83,10 @@ jobs:
       - name: Load Docker image
         run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
 
-      - name: Push container
-        working-directory: ./packages/titus-backend
-        run: docker push $DOCKER_IMAGE
+      - name: Push Docker image
+        run: |
+          echo $DOCKER_IMAGE
+          docker push $DOCKER_IMAGE
 
       - name: Run service
         uses: google-github-actions/deploy-cloudrun@v0.7.0

--- a/.github/workflows/db-manager-cd-gcp.yml
+++ b/.github/workflows/db-manager-cd-gcp.yml
@@ -1,4 +1,4 @@
-name: DB Manager CD to GCP
+name: 'DB Manager CD to GCP'
 
 on:
   push:
@@ -10,17 +10,15 @@ on:
 
 env:
   DOCKER_SAVE_ARTIFACT: docker-save.tar
+  DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
+  CLOUDRUN_SERVICE_NAME: titus-backend
+  CLOUDRUN_SERVICE_REGION: europe-west1
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-db-manager:
     name: Build titus-db-manager
     runs-on: ubuntu-latest
-
-    env:
-      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
-      CLOUDRUN_SERVICE_NAME: titus-db-manager
-      CLOUDRUN_SERVICE_REGION: europe-west1
 
     steps:
       - name: Checkout project
@@ -41,15 +39,11 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Configure Docker repository
+      - name: Configure Docker registry
         run: |
           gcloud components install beta
           gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
-
           echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/db-manager:$GITHUB_SHA" >> $GITHUB_ENV
-
-      - name: Install Grype tool (vulnerability scan)
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Build Docker image
         working-directory: ./packages/titus-db-manager
@@ -78,6 +72,20 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Configure Docker registry
+        run: |
+          gcloud components install beta
+          gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
+          echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/db-manager:$GITHUB_SHA" >> $GITHUB_ENV
+
       - name: Download Docker image from artifacts store
         uses: actions/download-artifact@v2
         with:
@@ -87,8 +95,7 @@ jobs:
       - name: Load Docker image
         run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
 
-      - name: Push container
-        working-directory: ./packages/titus-db-manager
+      - name: Push Docker image
         run: docker push $DOCKER_IMAGE
 
       - name: Run service
@@ -101,6 +108,7 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Delete Docker artifacts
+        if: always()
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.DOCKER_SAVE_ARTIFACT }}

--- a/.github/workflows/frontend-cd-gcp.yml
+++ b/.github/workflows/frontend-cd-gcp.yml
@@ -1,4 +1,4 @@
-name: Frontend CD to GCP
+name: 'Frontend CD to GCP'
 
 on:
   push:
@@ -10,17 +10,15 @@ on:
 
 env:
   DOCKER_SAVE_ARTIFACT: docker-save.tar
+  DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
+  CLOUDRUN_SERVICE_NAME: titus-backend
+  CLOUDRUN_SERVICE_REGION: europe-west1
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-frontend:
     name: Build titus-frontend
     runs-on: ubuntu-latest
-
-    env:
-      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
-      CLOUDRUN_SERVICE_NAME: titus-frontend
-      CLOUDRUN_SERVICE_REGION: europe-west1
 
     steps:
       - name: Checkout project
@@ -41,15 +39,11 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Configure Docker repository
+      - name: Configure Docker registry
         run: |
           gcloud components install beta
           gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
-
           echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/frontend:$GITHUB_SHA" >> $GITHUB_ENV
-
-      - name: Install Grype tool (vulnerability scan)
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Build container
         working-directory: ./packages/titus-frontend
@@ -80,6 +74,20 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Configure Docker registry
+        run: |
+          gcloud components install beta
+          gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
+          echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/frontend:$GITHUB_SHA" >> $GITHUB_ENV
+
       - name: Download Docker image from artifacts store
         uses: actions/download-artifact@v2
         with:
@@ -89,8 +97,7 @@ jobs:
       - name: Load Docker image
         run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
 
-      - name: Push container
-        working-directory: ./packages/titus-frontend
+      - name: Push Docker image
         run: docker push $DOCKER_IMAGE
 
       - name: Run service
@@ -103,6 +110,7 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Delete Docker artifacts
+        if: always()
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.DOCKER_SAVE_ARTIFACT }}

--- a/.github/workflows/storybook-cd-gcp.yml
+++ b/.github/workflows/storybook-cd-gcp.yml
@@ -1,4 +1,4 @@
-name: Storybook CD to GCP
+name: 'Storybook CD to GCP'
 
 on:
   push:
@@ -10,17 +10,15 @@ on:
 
 env:
   DOCKER_SAVE_ARTIFACT: docker-save.tar
+  DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
+  CLOUDRUN_SERVICE_NAME: titus-backend
+  CLOUDRUN_SERVICE_REGION: europe-west1
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-storybook:
     name: Build titus-storybook
     runs-on: ubuntu-latest
-
-    env:
-      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
-      CLOUDRUN_SERVICE_NAME: titus-storybook
-      CLOUDRUN_SERVICE_REGION: europe-west1
 
     steps:
       - name: Checkout project
@@ -41,15 +39,11 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Configure Docker repository
+      - name: Configure Docker registry
         run: |
           gcloud components install beta
           gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
-
           echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/storybook:$GITHUB_SHA" >> $GITHUB_ENV
-
-      - name: Install Grype tool (vulnerability scan)
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Build container
         working-directory: ./packages/titus-frontend
@@ -78,6 +72,20 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Configure Docker registry
+        run: |
+          gcloud components install beta
+          gcloud beta auth configure-docker $DOCKER_REGISTRY_HOST
+          echo "DOCKER_IMAGE=$DOCKER_REGISTRY_HOST/$PROJECT_ID/titus/storybook:$GITHUB_SHA" >> $GITHUB_ENV
+
       - name: Download Docker image from artifacts store
         uses: actions/download-artifact@v2
         with:
@@ -87,8 +95,7 @@ jobs:
       - name: Load Docker image
         run: docker load --input /tmp/$DOCKER_SAVE_ARTIFACT
 
-      - name: Push container
-        working-directory: ./packages/titus-frontend
+      - name: Push Docker image
         run: docker push $DOCKER_IMAGE
 
       - name: Run service
@@ -101,6 +108,7 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Delete Docker artifacts
+        if: always()
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.DOCKER_SAVE_ARTIFACT }}


### PR DESCRIPTION
After converting these workflows from single job to multi job, several assets (like environment variables and GCR auth) were missing in the deploy job. This PR fixes that issue and now the workflows can `docker push` again e.g. https://github.com/nearform/titus/actions/runs/1654648857)