### PR TITLE
chore: fix storybook deploy action

### DIFF
--- a/packages/titus-frontend/.storybook/main.js
+++ b/packages/titus-frontend/.storybook/main.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     '@storybook/addon-actions/register',
     '@storybook/addon-links/register',
-    '@storybook/addon-knobs/register',
+    '@storybook/addon-knobs',
     '@storybook/preset-create-react-app',
     'storybook-readme/register'
   ],


### PR DESCRIPTION
Fixes #1465 

This is just a temporary fix, to get the CI builds green again. The reason for the fails was the [deprecation of `addon-knobs`](https://github.com/storybookjs/storybook/discussions/15060), and apparently a bug introduced when it was being moved outside of the monorepo.

Storybook's API has been changing quite a lot within the last two major versions, and the current setup in titus could use a bit of an update (it actually no longer works when started locally).