### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}

--- a/.github/workflows/db-manager-cd-gcp.yml
+++ b/.github/workflows/db-manager-cd-gcp.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}

--- a/.github/workflows/frontend-cd-gcp.yml
+++ b/.github/workflows/frontend-cd-gcp.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}

--- a/.github/workflows/storybook-cd-gcp.yml
+++ b/.github/workflows/storybook-cd-gcp.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.