### PR TITLE
fix: detect production environment

### DIFF
--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -13,6 +13,7 @@ env:
   DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
   CLOUDRUN_SERVICE_NAME: titus-backend
   CLOUDRUN_SERVICE_REGION: europe-west1
+  IS_PRODUCTION: false
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
@@ -106,6 +107,8 @@ jobs:
           credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
+          env_vars: |
+            IS_PRODUCTION=${{ env.IS_PRODUCTION }}
 
       - name: Delete Docker artifacts
         if: always()

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -13,7 +13,7 @@ env:
   DOCKER_REGISTRY_HOST: europe-west1-docker.pkg.dev
   CLOUDRUN_SERVICE_NAME: titus-backend
   CLOUDRUN_SERVICE_REGION: europe-west1
-  IS_PRODUCTION: false
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-backend:

--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -14,7 +14,6 @@ env:
   CLOUDRUN_SERVICE_NAME: titus-backend
   CLOUDRUN_SERVICE_REGION: europe-west1
   IS_PRODUCTION: false
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   build-titus-backend:
@@ -107,8 +106,6 @@ jobs:
           credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
-          env_vars: |
-            IS_PRODUCTION=${{ env.IS_PRODUCTION }}
 
       - name: Delete Docker artifacts
         if: always()

--- a/infra/gcp/terraform/backend.tf
+++ b/infra/gcp/terraform/backend.tf
@@ -38,7 +38,7 @@ resource "google_cloud_run_service" "backend" {
         }
         env {
           name  = "IS_PRODUCTION"
-          value = true
+          value = var.is_production
         }
         env {
           name  = "CORS_ORIGIN"

--- a/infra/gcp/terraform/config.auto.tfvars.sample
+++ b/infra/gcp/terraform/config.auto.tfvars.sample
@@ -7,4 +7,6 @@ cloudsql_tier = "db-custom-1-3840" # where 1 means 1 CPU and 3840 means 3,75GB R
 cloudsql_db_name = "titus"
 cloudsql_db_user = "titus"
 
+is_production = "true"
+
 artifact_registry_repository_name = "titus"

--- a/infra/gcp/terraform/db-manager.tf
+++ b/infra/gcp/terraform/db-manager.tf
@@ -65,6 +65,10 @@ resource "google_cloud_run_service" "db_manager" {
           value = "production"
         }
         env {
+          name  = "IS_PRODUCTION"
+          value = true
+        }
+        env {
           name  = "AUTH0_DOMAIN"
           value = "dummy"
         }

--- a/infra/gcp/terraform/db-manager.tf
+++ b/infra/gcp/terraform/db-manager.tf
@@ -66,7 +66,7 @@ resource "google_cloud_run_service" "db_manager" {
         }
         env {
           name  = "IS_PRODUCTION"
-          value = true
+          value = var.is_production
         }
         env {
           name  = "AUTH0_DOMAIN"

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -7,4 +7,6 @@ variable "cloudsql_tier" {}
 variable "cloudsql_db_name" {}
 variable "cloudsql_db_user" {}
 
+variable "is_production" {}
+
 variable "artifact_registry_repository_name" {}


### PR DESCRIPTION
Since the deploy is failing due the missing required env `IS_PRODUCTION` I created an env and add a new parameter at the the deploy step to use the env