### PR TITLE
chore: replaced deprecated way of GCP authentication in cd workflow

### DIFF
--- a/.github/workflows/backend-cd-gcp.yml
+++ b/.github/workflows/backend-cd-gcp.yml
@@ -33,13 +33,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -74,13 +76,15 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -105,7 +109,6 @@ jobs:
         with:
           service: ${{ env.CLOUDRUN_SERVICE_NAME }}
           image: ${{ env.DOCKER_IMAGE }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
 

--- a/.github/workflows/db-manager-cd-gcp.yml
+++ b/.github/workflows/db-manager-cd-gcp.yml
@@ -33,13 +33,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -74,13 +76,15 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -105,7 +109,6 @@ jobs:
         with:
           service: ${{ env.CLOUDRUN_SERVICE_NAME }}
           image: ${{ env.DOCKER_IMAGE }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
 

--- a/.github/workflows/frontend-cd-gcp.yml
+++ b/.github/workflows/frontend-cd-gcp.yml
@@ -33,13 +33,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -76,13 +78,15 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -107,7 +111,6 @@ jobs:
         with:
           service: ${{ env.CLOUDRUN_SERVICE_NAME }}
           image: ${{ env.DOCKER_IMAGE }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
 

--- a/.github/workflows/storybook-cd-gcp.yml
+++ b/.github/workflows/storybook-cd-gcp.yml
@@ -33,13 +33,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -74,13 +76,15 @@ jobs:
     needs: docker-scan
 
     steps:
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure Docker registry
         run: |
@@ -105,7 +109,6 @@ jobs:
         with:
           service: ${{ env.CLOUDRUN_SERVICE_NAME }}
           image: ${{ env.DOCKER_IMAGE }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ env.CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ env.PROJECT_ID }}
 


### PR DESCRIPTION
Replaced deprecated way of GCP authentication along with instructions from [docs](https://github.com/google-github-actions/deploy-cloudrun#authenticating-via-service-account-key-json) and [docs](https://github.com/google-github-actions/setup-gcloud#authentication-inputs).

For warnings please see:
https://github.com/nearform/titus/actions/runs/2261365900
https://github.com/nearform/titus/actions/runs/2261365898
https://github.com/nearform/titus/actions/runs/2261365901
https://github.com/nearform/titus/actions/runs/2261365902