### PR TITLE
chore: remove optional github token frontend

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -78,5 +78,3 @@ jobs:
      contents: write       
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
remove optional github token from frontend